### PR TITLE
Enable reading of JEMRIS-generated .seq files

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -201,7 +201,11 @@ def get_block(self, block_index: int) -> SimpleNamespace:
                     grad.first = grad.waveform[0]
                     grad.last = grad.waveform[-1]
             else:
-                grad.amplitude, grad.rise_time, grad.flat_time, grad.fall_time, grad.delay = [lib_data[x] for x in
+                if max(lib_data.shape) < 5: # added by GT
+                    grad.amplitude, grad.rise_time, grad.flat_time, grad.fall_time = [lib_data[x] for x in range(4)]
+                    grad.delay = 0
+                else:
+                    grad.amplitude, grad.rise_time, grad.flat_time, grad.fall_time, grad.delay = [lib_data[x] for x in
                                                                                               range(5)]
                 grad.area = grad.amplitude * (grad.flat_time + grad.rise_time / 2 + grad.fall_time / 2)
                 grad.flat_area = grad.amplitude * grad.flat_time

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -216,9 +216,17 @@ class Sequence:
         rf.signal = amplitude * mag * np.exp(rf.signal)
         rf.t = np.arange(1, max(mag.shape) + 1) * self.rf_raster_time
 
-        rf.delay = lib_data[3]
-        rf.freq_offset = lib_data[4]
-        rf.phase_offset = lib_data[5]
+
+        if max(lib_data.shape) < 6:
+            rf.delay = 0
+            rf.freq_offset = lib_data[3]
+            rf.phase_offset = lib_data[4]
+            lib_data = np.append(lib_data, 0)
+        else:
+            rf.delay = lib_data[3]
+            rf.freq_offset = lib_data[4]
+            rf.phase_offset = lib_data[5]
+
 
         if max(lib_data.shape) < 7:
             lib_data = np.append(lib_data, 0)


### PR DESCRIPTION
This code edit is a quick fix to enable JEMRIS-generated pulseq .seq files (of an older version) to be read. The difference between the old and new Pulseq versions is in the number of fields for RF and trapezoidal gradients. 

* For RF pulses, PyPulseq 1.2.0 version uses **[id, amplitude, mag_id, phase_id, delay, freq, phase]**, but the JEMRIS version uses **[id, amplitude, mag_id, phase_id, freq, phase]**
* For trapezoidal gradients, PyPulseq 1.2.0 uses **[id, amplitude, rise, flat, fall, delay]**, but JEMRIS uses **[id, amplitude, rise, flat, fall]**

**NOTE : An empty section, [JEMRIS], must be manually added to the seq file before seq.read() can be called to parse it.**

Example:

```
# Pulseq sequence format
# Created by JEMRIS 2.8.3


[JEMRIS]

[DEFINITIONS]
id 1
Num_Blocks 192

# Format of blocks:
# #  D RF  GX  GY  GZ ADC
[BLOCKS]
  1  0  1   0   0   0  0
  2  1  0   0   0   0  0
  3  0  0   1   2   0  0

......
```

