### PR TITLE
change quant_factor to match MATLAB implementation

### DIFF
--- a/pypulseq/compress_shape.py
+++ b/pypulseq/compress_shape.py
@@ -17,7 +17,7 @@ def compress_shape(decompressed_shape: np.ndarray) -> np.ndarray:
     compressed_shape : SimpleNamespace
         A `SimpleNamespace` object containing the compressed data and corresponding shape.
     """
-    quant_factor = 1e-8
+    quant_factor = 1e-7
     decompressed_shape_scaled = decompressed_shape / quant_factor
     datq = np.round(np.insert(np.diff(decompressed_shape_scaled), 0, decompressed_shape_scaled[0]))
     qerr = decompressed_shape_scaled - np.cumsum(datq)


### PR DESCRIPTION
Change quantization factor in _compress_shape.py_ from 1e-8 to the MATLAB default value 1e-7. This solves issue https://github.com/imr-framework/pypulseq/issues/42. 