### PR TITLE
fix typo

### DIFF
--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -69,7 +69,7 @@ def make_arbitrary_rf(signal: np.ndarray, flip_angle: float, bandwidth: float = 
     signal = np.squeeze(signal)
     if signal.ndim > 1:
         raise ValueError(f'signal should have ndim=1. Passed ndim={signal.ndim}')
-    signal = signal / bp.abs(np.sum(signal * system.rf_raster_time)) * flip_angle / (2 * np.pi)
+    signal = signal / np.abs(np.sum(signal * system.rf_raster_time)) * flip_angle / (2 * np.pi)
 
     N = len(signal)
     duration = N * system.rf_raster_time

--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -121,4 +121,7 @@ def make_arbitrary_rf(signal: np.ndarray, flip_angle: float, bandwidth: float = 
         rf.t = np.concatenate((rf.t, rf.t[-1] + t_fill))
         rf.signal = np.concatenate((rf.signal, np.zeros(len(t_fill))))
 
-    return rf, gz if return_gz else rf
+    if return_gz:
+        return rf, gz
+    else:
+        return rf


### PR DESCRIPTION
Fixes a small typo in the arbitrary rf pulse and fix the return syntax