### PR TITLE
Fix missing install module for version.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     name="pypulseq",
     packages=setuptools.find_packages(),
+    py_modules=["version"],
     # package_data for wheel distributions; MANIFEST.in for source distributions
     package_data={"pypulseq.SAR": ["QGlobal.mat"]},
     project_urls={"Documentation": "https://pypulseq.readthedocs.io/en/latest/"},


### PR DESCRIPTION
version.py was not added as an install target and not copied into install directory. This causes an exception when imported from sequence.py. This commit adds it as py_module to setup.py.