### PR TITLE
Fix incorrect array creation at waveform_and_gradients().

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1175,10 +1175,10 @@ class Sequence:
                             )
                         else:  # Extended trapezoid
                             out_len[j] += len(grad.tt)
-                            shape_pieces[j, block_counter] = [
-                                [curr_dur + grad.delay + grad.tt],
-                                [grad.waveform],
-                            ]
+                            shape_pieces[j, block_counter] = np.array([
+                                curr_dur + grad.delay + grad.tt,
+                                grad.waveform,
+                            ])
                     else:
                         if np.abs(grad.flat_time) > eps:
                             out_len[j] += 4


### PR DESCRIPTION
The way extended trapezoids are added to the waveforms array was incorrect due to the outermost list not being numpy array, (thus, not having `.shape` property), and being wrapped in an additional list, which caused the shape to be (2, 1, N) instead of (2, N), where N is the number of waveform points. Both of these bugs caused separate exceptions.