### PR TITLE
[Feature Suggestion] Option to call plt.show() later for plotting.

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -729,7 +729,8 @@ class Sequence:
         save: bool = False,
         time_range=(0, np.inf),
         time_disp: str = "s",
-        grad_disp: str = "kHz/m"
+        grad_disp: str = "kHz/m",
+        plot_now: bool = True
     ) -> None:
         """
         Plot `Sequence`.
@@ -748,6 +749,11 @@ class Sequence:
             Time range (x-axis limits) for plotting the sequence. Default is 0 to infinity (entire sequence).
         time_disp : str, default='s'
             Time display type, must be one of `s`, `ms` or `us`.
+        grad_disp : str, default='s'
+            Gradient display unit, must be one of `kHz/m` or `mT/m`.
+        plot_now : bool, default=True
+            If true, function immediately shows the plots, blocking the rest of the code until plots are exited.
+            If false, plots are shown when plt.show() is called. Useful if plots are to be modified.
         plot_type : str, default='Gradient'
             Gradients display type, must be one of either 'Gradient' or 'Kspace'.
         """
@@ -937,7 +943,9 @@ class Sequence:
         if save:
             fig1.savefig("seq_plot1.jpg")
             fig2.savefig("seq_plot2.jpg")
-        plt.show()
+        
+        if plot_now:
+            plt.show()
 
     def read(self, file_path: str, detect_rf_use: bool = False) -> None:
         """


### PR DESCRIPTION
This PR adds an optional input parameter to seq.plot() that controls if plt.show() is to be called by the function or by the user. This is useful for Matplotlib, since, once show() is called, the rest of the script will be blocked till the plots are closed, meaning, no further modification on the plots can be done by the user.

A very convenient use case for me is adding data cursors, similar to Matlab's data tips using the [mplcursors](https://mplcursors.readthedocs.io/en/stable/index.html) library.