### PR TITLE
fix calculation of bandwidth of adiabatic hypsec pulse

### DIFF
--- a/pypulseq/calc_rf_bandwidth.py
+++ b/pypulseq/calc_rf_bandwidth.py
@@ -3,7 +3,7 @@ from typing import Union, Tuple
 
 import numpy as np
 
-from pypulseq import calc_rf_center
+from pypulseq.calc_rf_center import calc_rf_center
 
 
 def calc_rf_bandwidth(
@@ -41,7 +41,7 @@ def calc_rf_bandwidth(
     nn = np.round(1 / dw / dt)
     tt = np.arange(-np.floor(nn / 2), np.ceil(nn / 2) - 1) * dt
 
-    rfs = np.interp(xp=rf.t - time_center, fp=rf.sig, x=tt)
+    rfs = np.interp(xp=rf.t - time_center, fp=rf.signal, x=tt)
     spectrum = np.fft.fftshift(np.fft.fft(np.fft.fftshift(rfs)))
     w = np.arange(-np.floor(nn / 2), np.ceil(nn / 2) - 1) * dw
 
@@ -60,14 +60,7 @@ def calc_rf_bandwidth(
 
 def __find_flank(x, f, c):
     m = np.max(np.abs(f))
-    f = np.abs(f) / m - c
-    i = (f > 0)[0, 0]
+    f = np.abs(f) / m
+    i = np.argwhere(f > c)[0]
 
-    if i > 1:
-        f0 = f[i - 1]
-        f1 = f[i]
-        xf = (f1 * x[i - 1] - f0 * x[i]) / (f1 - f0)
-    else:
-        xf = x[0]
-
-    return xf
+    return x[i]

--- a/pypulseq/make_adiabatic_pulse.py
+++ b/pypulseq/make_adiabatic_pulse.py
@@ -6,7 +6,6 @@ from sigpy.mri.rf import hypsec, wurst
 
 from pypulseq import eps
 from pypulseq.calc_duration import calc_duration
-from pypulseq.calc_rf_bandwidth import calc_rf_bandwidth
 from pypulseq.calc_rf_center import calc_rf_center
 from pypulseq.make_delay import make_delay
 from pypulseq.make_trapezoid import make_trapezoid
@@ -221,7 +220,7 @@ def make_adiabatic_pulse(
             system.max_slew = max_slew
 
         if pulse_type == "hypsec":
-            bandwidth = calc_rf_bandwidth(rf, 0.1)
+            bandwidth = mu * beta / np.pi
         elif pulse_type == "wurst":
             bandwidth = bandwidth
         else:


### PR DESCRIPTION
When trying to use a slice selective adiabatic hypsec pulse, I got several errors related to the calculation of the bandwidth of the hypsec pulse. I fixed the obvious ones like a wrong import of _calc_rf_center()_ in _calc_rf_bandwidth()_ and a wrong attribute name (rf.sig instead of rf.signal) and provide a new solution for the ___find_flank()_ function:

```python
    def __find_flank(x, f, c):
       m = np.max(np.abs(f))
       f = np.abs(f) / m
       i = np.argwhere(f > c)[0]

       return x[i]
```

Using calc_rf_bandwidth() with a cut_off value of 0.5 instead of 0.1 (which makes sense imo because the signal gets normalized to 1 and we are interested in the width at half maximum ?!) yields a bw of 1280 Hz, which is close to the literaure value of ~ 1250 Hz for the hypsec pulse with default settings (beta = 800, mu =4.9)

HOWEVER, simply using the analytic expression for the bw of a hypsec pulse makes far more sense imo. It is given by 

**bw = mu * beta / pi** 

As a reference, here the passage from Bernstein - Handbook of MRI pulse sequences:

![grafik](https://user-images.githubusercontent.com/37338697/182788880-3e8d21d9-94ae-4e9e-bae6-47be6b2e3cd7.png)

Using the analytic expression is the way I implemented it now in _make_adiabatic_pulse.py_