### PR TITLE
Add missing input set case for trapezoids.

### DIFF
--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -84,6 +84,8 @@ def make_trapezoid(
     if flat_time != -1:
         if amplitude != 0:
             amplitude2 = amplitude
+        elif (area != 0) and (rise_time > 0): # We have rise_time, flat_time and area.
+            amplitude2 = area/(rise_time + flat_time)
         else:
             amplitude2 = flat_area / flat_time
 


### PR DESCRIPTION
There is a missing case for defining trapezoids, when rise time, flat time and area is given. It causes the amplitude to be calculated as flat_area/flat_time, which evaluates to 0 and causes trapezoid to be a 0 area trapezoid. This commit adds the missing case. 