### PR TITLE
Fix side effects of using numpy.round

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -633,14 +633,14 @@ class Sequence:
         ty_e = 0 if ty.size==0 else ty[-1]
         tz_e = 0 if tz.size==0 else tz[-1]
 
-        max_t = np.round(np.max(tx_e, ty_e, tz_e)/dt)*dt
+        max_t = np.round(np.max((tx_e, ty_e, tz_e))/dt)*dt
 
-        gx_i = np.round((tx_s)/dt)
-        gy_i = np.round((ty_s)/dt)
-        gz_i = np.round((tz_s)/dt)
+        gx_i = int(np.rint((tx_s)/dt))
+        gy_i = int(np.rint((ty_s)/dt))
+        gz_i = int(np.rint((tz_s)/dt))
 
         # Create array for waveforms and insert into respective axes
-        grad_waveforms = np.zeros((3, np.round(max_t/dt)))
+        grad_waveforms = np.zeros((3, int(np.rint(max_t/dt))))
 
         grad_waveforms[0, gx_i:(gx_i+gx.shape[0])] = gx
         grad_waveforms[1, gy_i:(gy_i+gy.shape[0])] = gy

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -625,22 +625,16 @@ class Sequence:
         gz = points_to_waveform(times=tz, amplitudes=ws[2][1], grad_raster_time=dt)
 
         # Check for empty arrays, set end and starting times
-        tx_s = 0 if tx.size==0 else tx[0]
-        ty_s = 0 if ty.size==0 else ty[0]
-        tz_s = 0 if tz.size==0 else tz[0]
+        tx_s, tx_e = (0,0) if tx.size==0 else (tx[0], tx[-1])
+        ty_s, ty_e = (0,0) if ty.size==0 else (ty[0], ty[-1])
+        tz_s, tz_e = (0,0) if tz.size==0 else (tz[0], tz[-1])
 
-        tx_e = 0 if tx.size==0 else tx[-1]
-        ty_e = 0 if ty.size==0 else ty[-1]
-        tz_e = 0 if tz.size==0 else tz[-1]
+        maxt_i = int(np.max((tx_e, ty_e, tz_e))/dt)
 
-        max_t = np.round(np.max((tx_e, ty_e, tz_e))/dt)*dt
-
-        gx_i = int(np.rint((tx_s)/dt))
-        gy_i = int(np.rint((ty_s)/dt))
-        gz_i = int(np.rint((tz_s)/dt))
+        gx_i, gy_i, gz_i = (int(tx_s/dt), int(ty_s/dt), int(tz_s/dt))
 
         # Create array for waveforms and insert into respective axes
-        grad_waveforms = np.zeros((3, int(np.rint(max_t/dt))))
+        grad_waveforms = np.zeros((3, maxt_i))
 
         grad_waveforms[0, gx_i:(gx_i+gx.shape[0])] = gx
         grad_waveforms[1, gy_i:(gy_i+gy.shape[0])] = gy


### PR DESCRIPTION
This commit fixes the bugs introduced in #84 due to numpy's rounding function.
np.round outputs the value as np.float64, which can not be automatically cast as int, thus, can not be used for slicing the arrays.