### PR TITLE
Cast times and amplitude inputs to np array in case they are supplied as list.

### DIFF
--- a/pypulseq/make_extended_trapezoid.py
+++ b/pypulseq/make_extended_trapezoid.py
@@ -64,6 +64,9 @@ def make_extended_trapezoid(
         raise ValueError(
             f"Invalid channel. Must be one of 'x', 'y' or 'z'. Passed: {channel}"
         )
+    
+    times = np.asarray(times)
+    amplitudes = np.asarray(amplitudes)
 
     if len(times) != len(amplitudes):
         raise ValueError("Times and amplitudes must have the same length.")


### PR DESCRIPTION
Sometimes it is more convenient to supply times and amplitudes as Python list instead of np.array to avoid boilerplate. In fact, it is what is done in "Tong et al. A framework for validating open-source pulse sequences. MRM. 2022. (https://doi.org/10.1016/j.mri.2021.11.014)", so IRSE and TSE sequences are currently failing in PyPulseq 1.4.  This PR aims to introduce this convenience, and make this branch more "backwards compatible".

Usage of np.asarray is almost free in this context, because:
1. It does nothing if the input is already numpy array, so no funny business or slowdown.
2. If the input is a list, it automatically does what the user would do manually for average use case: ie. np.array([1, 2, 3 .....]).

PS: IMHO, every function that gets an ArrayLike, should have asarray casts for their respective inputs.