### PR TITLE
Fix usage of np.max

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -633,7 +633,7 @@ class Sequence:
         ty_e = 0 if ty.size==0 else ty[-1]
         tz_e = 0 if tz.size==0 else tz[-1]
 
-        max_t = np.round(np.max(tx_e, ty_e, tz_e)/dt)*dt
+        max_t = np.round(np.max((tx_e, ty_e, tz_e))/dt)*dt
 
         gx_i = np.round((tx_s)/dt)
         gy_i = np.round((ty_s)/dt)


### PR DESCRIPTION
Before, the three values were interpreted as thee parameters to the max function, i.e. as array, axis and out instead of choosing the maximum of those values.
This issue was introduced by #84 
Just passing the values as a tuple fixes this