### PR TITLE
Add missing shape_dur property to arbitrary RF.

### DIFF
--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -94,6 +94,7 @@ def make_arbitrary_rf(
     rf.type = "rf"
     rf.signal = signal
     rf.t = t
+    rf.shape_dur = duration
     rf.freq_offset = freq_offset
     rf.phase_offset = phase_offset
     rf.dead_time = system.rf_dead_time


### PR DESCRIPTION
make_arbitrary_rf.py has a missing shape_dur property.