### PR TITLE
waveforms_and_times append RF fixes

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1203,18 +1203,21 @@ class Sequence:
                         [curr_dur + t, block.rf.freq_offset, block.rf.phase_offset]
                     )
                 if append_RF:
-                    pre = []
-                    post = []
+                    rf_piece = np.array([curr_dur + rf.delay + rf.t, rf.signal*np.exp(1j*(rf.phase_offset+2*np.pi*rf.freq_offset*rf.t))])
+                    out_len[-1] += len(rf.t)
+
                     if np.abs(rf.signal[0]) > 0:
                         pre = np.array([[curr_dur + rf.delay + rf.t[0] - eps], [0]])
+                        rf_piece = np.hstack((pre, rf_piece))
+                        out_len[-1] += pre.shape[1]
 
                     if np.abs(rf.signal[-1]) > 0:
                         post = np.array([[curr_dur + rf.delay + rf.t[-1] + eps], [0]])
+                        rf_piece = np.hstack((rf_piece, post))
+                        out_len[-1] += post.shape[1]
 
-                    out_len[-1] += len(rf.t) + pre.shape[1] + post.shape[1]
-                    shape_pieces[-1, block_counter] = np.hstack(
-                        (pre, [curr_dur + rf.delay + rf.t, rf.signal*np.exp(1j*(rf.phase_offset+2*np.pi*rf.freq_offset*rf.t))], post)
-                    )
+                    shape_pieces[-1, block_counter] = rf_piece
+
 
             if block.adc is not None:  # ADC
                 t_adc.extend(


### PR DESCRIPTION
Waveforms and times with append RF parameter is not functioning properly, due to improper casts and some missing logics. Also, it was omitting the phase and frequency offsets.

This is a hacky fix and open to discussion. Upstream MATLAB implementation uses cell arrays for storing the time/waveform pairs, which is more flexible than the numpy arrays and nested lists used here. As the RF waveform is complex, usage of np array forces the associated time points to be complex as well, which is a bit awkward and inefficient.

I have two proposals for a better solution:

1) We can switch to dictionaries, and only the time points and waveform would be np arrays. Example usage:

```python
waves['gx']['t'] # For time points
waves['gx']['s'] # For waveform
waves['rf']['s'] # For waveform (only this one is complex)
```

I think this will be a more flexible, verbose and Pythonic way of doing this, but it slightly deviates from upstream.

2) We can split RF into phase and magnitude so that the RF list will be like:

```python
waves[3][0] # RF time
waves[3][1] # RF magnitude
waves[3][2] # RF phase
```

This will deviate less from the upstream, but adds even more complication to the output of this function, which I think feels confusing and hard-coded right now.
