### PR TITLE
np.int is deprecated in numpy>=1.20.0

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -38,7 +38,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
         If a gradient that doesn't end at zero is not aligned to the block boundary.
     """
     events = block_to_events(*args)
-    self.block_events[block_index] = np.zeros(7, dtype=np.int)
+    self.block_events[block_index] = np.zeros(7, dtype=np.int32)
     duration = 0
 
     check_g = {}  # Key-value mapping of index and  pairs of gradients/times

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -526,7 +526,7 @@ def __read_and_parse_events(input_file, *args: callable) -> EventLibrary:
     while line != "" and line != "#":
         datas = re.split("(\s+)", line)
         datas = [d for d in datas if d != " "]
-        data = np.zeros(len(datas) - 1, dtype=np.int)
+        data = np.zeros(len(datas) - 1, dtype=np.int32)
         event_id = int(datas[0])
         for i in range(1, len(datas)):
             if i > len(args):

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -216,7 +216,7 @@ class Sequence:
         i_refocusing = np.round(t_refocusing / self.grad_raster_time)
         i_periods = np.sort(
             [1, *(i_excitation + 1), *(i_refocusing + 1), gw.shape[1] + 1]
-        ).astype(np.int)
+        ).astype(np.int32)
         # i_periods -= 1  # Python is 0-indexed
         ii_next_excitation = np.min((len(i_excitation), 1))
         ii_next_refocusing = np.min((len(i_refocusing), 1))

--- a/pypulseq/compress_shape.py
+++ b/pypulseq/compress_shape.py
@@ -45,7 +45,7 @@ def compress_shape(
     qerr = decompressed_shape_scaled - np.cumsum(datq)
     qcor = np.insert(np.diff(np.round(qerr)), 0, 0)
     datd = datq + qcor
-    mask_changes = np.insert(np.asarray(np.diff(datd) != 0, dtype=np.int), 0, 1)
+    mask_changes = np.insert(np.asarray(np.diff(datd) != 0, dtype=np.int32), 0, 1)
     vals = datd[mask_changes.nonzero()[0]] * quant_factor
 
     k = np.append(mask_changes, 1).nonzero()[0]


### PR DESCRIPTION
With the current requirements in [setup.py](https://github.com/imr-framework/pypulseq/blob/dev/setup.py#L37) numpy >=1.20 will be installed where `np.int` is deprecated.

Changing all occurrences of `np.int` to `np.int32` is compatible with both `1.19.5 <= numpy <= 1.20.0`, and `numpy >= 1.20.0` (tested with 1.23.5). `np.int` can also be changed to `np.int64` if necessary.