### PR TITLE
Replace np.float with np.float64

### DIFF
--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -300,7 +300,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
 
                 # Bookkeeping
                 grad_prev_last[j] = grad.last
-                eps = np.finfo(np.float).eps
+                eps = np.finfo(np.float64).eps
                 if grad_duration + eps < block_duration:
                     grad_prev_last[j] = 0
 

--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -15,7 +15,7 @@ def round_half_up(n, decimals=0):
 # =========
 # NP.FLOAT EPSILON
 # =========
-eps = np.finfo(np.float).eps
+eps = np.finfo(np.float64).eps
 
 # =========
 # PACKAGE-LEVEL IMPORTS


### PR DESCRIPTION
np.float is deprecated in numpy 1.20. Replacing it with the equivalent np.float64.