### PR TITLE
Several bug fixes in `Sequence`, `add_gradients`, `make_trapezoid`, and `rotate`

### DIFF
--- a/pypulseq/Sequence/ext_test_report.py
+++ b/pypulseq/Sequence/ext_test_report.py
@@ -140,7 +140,7 @@ def ext_test_report(self) -> str:
     # gw_data = self.gradient_waveforms()
     waveforms_and_times = self.waveforms_and_times()
     gw_data = waveforms_and_times[0]
-    gws = np.zeros_like(gw_data)
+    gws = [np.zeros_like(x) for x in gw_data]
     ga = np.zeros(len(gw_data))
     gs = np.zeros(len(gw_data))
 

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1392,11 +1392,11 @@ class Sequence:
                             # TODO: Implement restoreAdditionalShapeSamples
                             #       https://github.com/pulseq/pulseq/blob/master/matlab/%2Bmr/restoreAdditionalShapeSamples.m
                             
-                            out_len[j] += len(grad.tt)
+                            out_len[j] += len(grad.tt)+2
                             shape_pieces[j].append(np.array(
                                 [
-                                    curr_dur + grad.delay + grad.tt,
-                                    grad.waveform,
+                                    curr_dur + grad.delay + np.concatenate(([0], grad.tt, [grad.tt[-1] + self.grad_raster_time/2])),
+                                    np.concatenate(([grad.first], grad.waveform, [grad.last]))
                                 ]
                             ))
                         else:  # Extended trapezoid
@@ -1509,7 +1509,6 @@ class Sequence:
 
             wave_data.append(np.concatenate(shape_pieces[j], axis=1))
 
-        for j in range(shape_channels):
             rftdiff = np.diff(wave_data[j][0])
             if np.any(rftdiff < eps):
                 raise Warning(

--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -30,6 +30,7 @@ from pypulseq.calc_rf_bandwidth import calc_rf_bandwidth
 from pypulseq.calc_rf_center import calc_rf_center
 from pypulseq.make_adc import make_adc
 from pypulseq.make_adiabatic_pulse import make_adiabatic_pulse
+from pypulseq.make_arbitrary_grad import make_arbitrary_grad
 from pypulseq.make_arbitrary_rf import make_arbitrary_rf
 from pypulseq.make_block_pulse import make_block_pulse
 from pypulseq.make_sigpy_pulse import *

--- a/pypulseq/rotate.py
+++ b/pypulseq/rotate.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from pypulseq.add_gradients import add_gradients
 from pypulseq.scale_grad import scale_grad
+from pypulseq.opts import Opts
 
 
 def __get_grad_abs_mag(grad: SimpleNamespace) -> np.ndarray:
@@ -17,6 +18,7 @@ def rotate(
     *args: SimpleNamespace,
     angle: float,
     axis: str,
+    system=Opts()
 ) -> List[SimpleNamespace]:
     """
     Rotates the corresponding gradient(s) about the given axis by the specified amount. Gradients parallel to the
@@ -85,7 +87,7 @@ def rotate(
         max_mag = np.max((max_mag, __get_grad_abs_mag(g)))
         rotated2.append(scale_grad(grad=g, scale=np.cos(angle)))
         g = scale_grad(grad=g, scale=-np.sin(angle))
-        g.channel = axes_to_rotate[1]
+        g.channel = axes_to_rotate[0]
         rotated1.append(g)
 
     # Eliminate zero-amplitude gradients
@@ -99,17 +101,11 @@ def rotate(
 
     # Add gradients on the corresponding axis together
     g = []
-    if len(rotated1) > 1:
-        g.append(add_gradients(grads=rotated1))
-    else:
-        if len(rotated1) != 0:
-            g.append(rotated1[0])
+    if len(rotated1) != 0:
+        g.append(add_gradients(grads=rotated1, system=system))
 
-    if len(rotated2) > 1:
-        g.append(add_gradients(grads=rotated2))
-    else:
-        if len(rotated2) != 0:
-            g.append(rotated2[0])
+    if len(rotated2) != 0:
+        g.append(add_gradients(grads=rotated2, system=system))
 
     # Eliminate zero amplitude gradients
     for i in range(len(g) - 1, -1, -1):


### PR DESCRIPTION
- Bypass code for `restoreAdditionalShapeSamples` did not include `grad.first` and `grad.last`
- `make_arbitrary_grad` was not available as `pp.make_arbitrary_grad`
- `add_gradients`' detection of arbitrary gradients was incorrect for Python's 0-based indexing
- `add_gradients` handling of non-unique times was broken
- `make_trapezoid` incorrectly checked and reported the minimum duration for gradients specifying area and duration (also fixed in local upstream MATLAB pulseq)
- `rotate` did not have a system parameter
- `rotate` used the incorrect channel for gradient on the second rotation axis

- Small change in `add_gradients` to accept a single gradient (i.e. for cases where a variable number of gradients are added), which also allowed a minor cleanup in `rotate`