### PR TITLE
Performance improvements

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -1,3 +1,4 @@
+import math
 from types import SimpleNamespace
 from typing import Tuple, List, Union
 
@@ -62,12 +63,12 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
 
                 grad_start = (
                     event.delay
-                    + np.floor(event.tt[0] / self.grad_raster_time + 1e-10)
+                    + math.floor(event.tt[0] / self.grad_raster_time + 1e-10)
                     * self.grad_raster_time
                 )
                 grad_duration = (
                     event.delay
-                    + np.ceil(event.tt[-1] / self.grad_raster_time - 1e-10)
+                    + math.ceil(event.tt[-1] / self.grad_raster_time - 1e-10)
                     * self.grad_raster_time
                 )
 
@@ -82,7 +83,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                     grad_id, _ = register_grad_event(self, event)
 
                 self.block_events[block_index][idx] = grad_id
-                duration = np.max([duration, grad_duration])
+                duration = max(duration, grad_duration)
             elif event.type == "trap":
                 channel_num = ["x", "y", "z"].index(event.channel)
                 idx = 2 + channel_num
@@ -106,14 +107,12 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                     trap_id = register_grad_event(self, event)
 
                 self.block_events[block_index][idx] = trap_id
-                duration = np.max(
-                    [
+                duration = max(
                         duration,
                         event.delay
                         + event.rise_time
                         + event.flat_time
-                        + event.fall_time,
-                    ]
+                        + event.fall_time
                 )
             elif event.type == "adc":
                 if hasattr(event, "id"):
@@ -122,14 +121,12 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                     adc_id = register_adc_event(self, event)
 
                 self.block_events[block_index][5] = adc_id
-                duration = np.max(
-                    [
+                duration = max(
                         duration,
-                        event.delay + event.num_samples * event.dwell + event.dead_time,
-                    ]
+                        event.delay + event.num_samples * event.dwell + event.dead_time
                 )
             elif event.type == "delay":
-                duration = np.max([duration, event.delay])
+                duration = max(duration, event.delay)
             elif event.type in ["output", "trigger"]:
                 if hasattr(event, "id"):
                     event_id = event.id
@@ -138,7 +135,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
 
                 ext = {"type": self.get_extension_type_ID("TRIGGERS"), "ref": event_id}
                 extensions.append(ext)
-                duration = np.max([duration, event.delay + event.duration])
+                duration = max(duration, event.delay + event.duration)
             elif event.type in ["labelset", "labelinc"]:
                 if hasattr(event, "id"):
                     label_id = event.id

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -74,8 +74,8 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
 
                 check_g[channel_num] = SimpleNamespace()
                 check_g[channel_num].idx = idx
-                check_g[channel_num].start = np.array((grad_start, event.first))
-                check_g[channel_num].stop = np.array((grad_duration, event.last))
+                check_g[channel_num].start = (grad_start, event.first)
+                check_g[channel_num].stop = (grad_duration, event.last)
 
                 if hasattr(event, "id"):
                     grad_id = event.id
@@ -90,16 +90,14 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
 
                 check_g[channel_num] = SimpleNamespace()
                 check_g[channel_num].idx = idx
-                check_g[channel_num].start = np.array((0, 0))
-                check_g[channel_num].stop = np.array(
-                    (
+                check_g[channel_num].start = (0, 0)
+                check_g[channel_num].stop = (
                         event.delay
                         + event.rise_time
                         + event.fall_time
                         + event.flat_time,
                         0,
                     )
-                )
 
                 if hasattr(event, "id"):
                     trap_id = event.id

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -627,14 +627,15 @@ def register_rf_event(self, event: SimpleNamespace) -> Tuple[int, List[int]]:
         shape_IDs[1], found = self.shape_library.find_or_insert(data)
         may_exist = may_exist & found
 
-        time_shape = compress_shape(
-            event.t / self.rf_raster_time
-        )  # Time shape is stored in units of RF raster
-        if len(time_shape.data) == 4 and np.all(
-            time_shape.data == [0.5, 1, 1, time_shape.num_samples - 3]
-        ):
+
+        t_regular = (np.floor(event.t/self.rf_raster_time) == np.arange(len(event.t))).all()
+
+        if t_regular:
             shape_IDs[2] = 0
         else:
+            time_shape = compress_shape(
+                event.t / self.rf_raster_time
+            )
             data = [time_shape.num_samples, *time_shape.data]
             shape_IDs[2], found = self.shape_library.find_or_insert(data)
             may_exist = may_exist & found

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -336,7 +336,7 @@ def get_block(self, block_index: int) -> SimpleNamespace:
     if event_ind[5] > 0:
         lib_data = self.adc_library.data[event_ind[5]]
         if len(lib_data) < 6:
-            lib_data = np.append(lib_data, 0)
+            lib_data = np.concatenate((lib_data, [0]))
 
         adc = SimpleNamespace()
         (
@@ -513,7 +513,7 @@ def register_grad_event(
             else:
                 g = event.waveform
             c_shape = compress_shape(g)
-            s_data = np.insert(c_shape.data, 0, c_shape.num_samples)
+            s_data = np.concatenate(([c_shape.num_samples], c_shape.data))
             shape_IDs[0], found = self.shape_library.find_or_insert(s_data)
             may_exist = may_exist & found
             any_changed = any_changed or found
@@ -524,7 +524,7 @@ def register_grad_event(
                 len(c_time.data) == 4
                 and np.all(c_time.data == [0.5, 1, 1, c_time.num_samples - 3])
             ):
-                t_data = np.insert(c_time.data, 0, c_time.num_samples)
+                t_data = np.concatenate(([c_time.num_samples], c_time.data))
                 shape_IDs[1], found = self.shape_library.find_or_insert(t_data)
                 may_exist = may_exist & found
                 any_changed = any_changed or found
@@ -621,12 +621,12 @@ def register_rf_event(self, event: SimpleNamespace) -> Tuple[int, List[int]]:
         shape_IDs = [0, 0, 0]
 
         mag_shape = compress_shape(mag)
-        data = np.insert(mag_shape.data, 0, mag_shape.num_samples)
+        data = np.concatenate(([mag_shape.num_samples], mag_shape.data))
         shape_IDs[0], found = self.shape_library.find_or_insert(data)
         may_exist = may_exist & found
 
         phase_shape = compress_shape(phase)
-        data = np.insert(phase_shape.data, 0, phase_shape.num_samples)
+        data = np.concatenate(([phase_shape.num_samples], phase_shape.data))
         shape_IDs[1], found = self.shape_library.find_or_insert(data)
         may_exist = may_exist & found
 

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -161,7 +161,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
         all_found = True
         extension_id = 0
         for i in range(len(extensions)):
-            data = [extensions[i]["type"], extensions[i]["ref"], extension_id]
+            data = (extensions[i]["type"], extensions[i]["ref"], extension_id)
             extension_id, found = self.extensions_library.find(data)
             all_found = all_found and found
             if not found:
@@ -171,7 +171,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
             # Add the list
             extension_id = 0
             for i in range(len(extensions)):
-                data = [extensions[i]["type"], extensions[i]["ref"], extension_id]
+                data = (extensions[i]["type"], extensions[i]["ref"], extension_id)
                 extension_id, found = self.extensions_library.find(data)
                 if not found:
                     self.extensions_library.insert(extension_id, data)
@@ -422,16 +422,14 @@ def register_adc_event(self, event: EventLibrary) -> int:
     int
         ID of registered ADC event.
     """
-    data = np.array(
-        [
+    data = (
             event.num_samples,
             event.dwell,
             max(event.delay, event.dead_time),
             event.freq_offset,
             event.phase_offset,
             event.dead_time,
-        ]
-    )
+        )
     adc_id, found = self.adc_library.find_or_insert(new_data=data)
 
     # Clear block cache because ADC was overwritten
@@ -465,7 +463,7 @@ def register_control_event(self, event: SimpleNamespace) -> int:
     else:
         raise ValueError("Unsupported control event type")
 
-    data = [event_type + 1, event_channel + 1, event.delay, event.duration]
+    data = (event_type + 1, event_channel + 1, event.delay, event.duration)
     control_id, found = self.trigger_library.find_or_insert(new_data=data)
 
     # Clear block cache because trigger was overwritten
@@ -526,17 +524,15 @@ def register_grad_event(
                 may_exist = may_exist & found
                 any_changed = any_changed or found
 
-        data = [amplitude, *shape_IDs, event.delay, event.first, event.last]
+        data = (amplitude, *shape_IDs, event.delay, event.first, event.last)
     elif event.type == "trap":
-        data = np.array(
-            [
+        data = (
                 event.amplitude,
                 event.rise_time,
                 event.flat_time,
                 event.fall_time,
                 event.delay,
-            ]
-        )
+            )
     else:
         raise ValueError("Unknown gradient type passed to register_grad_event()")
 
@@ -573,7 +569,7 @@ def register_label_event(self, event: SimpleNamespace) -> int:
     """
 
     label_id = get_supported_labels().index(event.label) + 1
-    data = [event.value, label_id]
+    data = (event.value, label_id)
     if event.type == "labelset":
         label_id, found = self.label_set_library.find_or_insert(new_data=data)
     elif event.type == "labelinc":
@@ -653,9 +649,7 @@ def register_rf_event(self, event: SimpleNamespace) -> Tuple[int, List[int]]:
         else:
             use = "u"
 
-    data = np.array(
-        [amplitude, *shape_IDs, event.delay, event.freq_offset, event.phase_offset]
-    )
+    data = (amplitude, *shape_IDs, event.delay, event.freq_offset, event.phase_offset)
 
     if may_exist:
         rf_id, found = self.rf_library.find_or_insert(new_data=data, data_type=use)

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -333,8 +333,6 @@ def get_block(self, block_index: int) -> SimpleNamespace:
     # ADC
     if event_ind[5] > 0:
         lib_data = self.adc_library.data[event_ind[5]]
-        if len(lib_data) < 6:
-            lib_data = np.concatenate((lib_data, [0]))
 
         adc = SimpleNamespace()
         (

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -426,7 +426,7 @@ def register_adc_event(self, event: EventLibrary) -> int:
         [
             event.num_samples,
             event.dwell,
-            np.max([event.delay, event.dead_time]),
+            max(event.delay, event.dead_time),
             event.freq_offset,
             event.phase_offset,
             event.dead_time,

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -518,12 +518,11 @@ def register_grad_event(
             may_exist = may_exist & found
             any_changed = any_changed or found
 
-            c_time = compress_shape(event.tt / self.grad_raster_time)
+            # Check whether tt == np.arange(len(event.tt)) * self.grad_raster_time + 0.5
+            tt_regular = (np.floor(event.tt/self.grad_raster_time) == np.arange(len(event.tt))).all()
 
-            if not (
-                len(c_time.data) == 4
-                and np.all(c_time.data == [0.5, 1, 1, c_time.num_samples - 3])
-            ):
+            if not tt_regular:
+                c_time = compress_shape(event.tt / self.grad_raster_time)
                 t_data = np.concatenate(([c_time.num_samples], c_time.data))
                 shape_IDs[1], found = self.shape_library.find_or_insert(t_data)
                 may_exist = may_exist & found

--- a/pypulseq/Sequence/calc_pns.py
+++ b/pypulseq/Sequence/calc_pns.py
@@ -1,5 +1,7 @@
+import math
 from types import SimpleNamespace
 from typing import Tuple
+
 import matplotlib.pyplot as plt
 import pypulseq as pp
 import numpy as np
@@ -59,8 +61,8 @@ def calc_pns(
             tf.append(gw[i][0,0])
             tl.append(gw[i][0,-1])
 
-    nt_min = np.floor(min(tf) / obj.grad_raster_time + pp.eps) 
-    nt_max = np.ceil(max(tl) / obj.grad_raster_time - pp.eps)
+    nt_min = math.floor(min(tf) / obj.grad_raster_time + pp.eps) 
+    nt_max = math.ceil(max(tl) / obj.grad_raster_time - pp.eps)
     
     # shift raster positions to the centers of the raster periods
     nt_min = nt_min + 0.5
@@ -68,7 +70,7 @@ def calc_pns(
     if nt_min < 0.5:
         nt_min = 0.5
 
-    t_axis = (np.arange(0,np.floor(nt_max-nt_min) + 1) + nt_min) * obj.grad_raster_time
+    t_axis = (np.arange(0, math.floor(nt_max-nt_min) + 1) + nt_min) * obj.grad_raster_time
 
     gwr = np.zeros((t_axis.shape[0],3))
     for i in range(3):

--- a/pypulseq/Sequence/ext_test_report.py
+++ b/pypulseq/Sequence/ext_test_report.py
@@ -87,7 +87,7 @@ def ext_test_report(self) -> str:
         k_storage_next = 0
         k_map = dict()
         for i in range(k_len):
-            key_string = str(
+            key_string = tuple(
                 (k_bins + np.round(k_traj_adc[:, i] / k_threshold)).astype(np.int32)
             )
             k_storage_ind = k_map.get(key_string)

--- a/pypulseq/Sequence/ext_test_report.py
+++ b/pypulseq/Sequence/ext_test_report.py
@@ -86,10 +86,9 @@ def ext_test_report(self) -> str:
         k_storage = np.zeros(k_len)
         k_storage_next = 0
         k_map = dict()
+        keys = np.round(k_traj_adc / k_threshold).astype(np.int32)
         for i in range(k_len):
-            key_string = tuple(
-                (k_bins + np.round(k_traj_adc[:, i] / k_threshold)).astype(np.int32)
-            )
+            key_string = tuple(keys[:,i])
             k_storage_ind = k_map.get(key_string)
             if k_storage_ind is None:
                 k_storage_ind = k_storage_next
@@ -113,13 +112,14 @@ def ext_test_report(self) -> str:
         k_counters = np.zeros_like(k_traj_rep1)
         dims = k_traj_rep1.shape[0]
         
+        keys = keys[:, k_repeat == 1]
         for j in range(dims):
             k_map = dict()
             k_storage = np.zeros(k_len)
             k_storage_next = 0
 
             for i in range(k_traj_rep1.shape[1]):
-                key = np.round(k_traj_rep1[j, i] / k_threshold).astype(np.int32)
+                key = keys[j,i]
                 k_storage_ind = k_map.get(key)
                 if k_storage_ind is None:
                     k_storage_ind = k_map.get(key + 1)

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -165,7 +165,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
                 )
         elif section == "[ADC]":
             self.adc_library = __read_events(
-                input_file, (1, 1e-9, 1e-6, 1, 1), event_library=self.adc_library
+                input_file, (1, 1e-9, 1e-6, 1, 1), event_library=self.adc_library, append=self.system.adc_dead_time
             )
         elif section == "[DELAYS]":
             if version_combined >= 1004000:
@@ -469,6 +469,7 @@ def __read_events(
     scale: tuple = (1,),
     event_type: str = str(),
     event_library: EventLibrary = EventLibrary(),
+    append=None
 ) -> EventLibrary:
     """
     Read an event section of a sequence file and return a library of events.
@@ -494,7 +495,9 @@ def __read_events(
     while line != "" and line != "#":
         data = np.fromstring(line, dtype=float, sep=" ")
         event_id = data[0]
-        data = data[1:] * scale
+        data = tuple(data[1:] * scale)
+        if append != None:
+            data = data + (append,)
         if event_type == "":
             event_library.insert(key_id=event_id, new_data=data)
         else:

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -225,7 +225,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
             if self.grad_library.type[i] == "t":
                 if self.grad_library.data[i][1] == 0:
                     if (
-                        np.abs(self.grad_library.data[i][0]) == 0
+                        abs(self.grad_library.data[i][0]) == 0
                         and self.grad_library.data[i][2] > 0
                     ):
                         self.grad_library.data[i][2] -= self.grad_raster_time
@@ -233,7 +233,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
 
                 if self.grad_library.data[i][3] == 0:
                     if (
-                        np.abs(self.grad_library.data[i][0]) == 0
+                        abs(self.grad_library.data[i][0]) == 0
                         and self.grad_library.data[i][2] > 0
                     ):
                         self.grad_library.data[i][2] -= self.grad_raster_time

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -424,7 +424,7 @@ class Sequence:
         def fnint(arr_poly):
             pieces = len(arr_poly)
             breaks = np.stack([pp.domain for pp in arr_poly])
-            breaks = np.append(breaks[:, 0], breaks[-1, 1])
+            breaks = np.concatenate((breaks[:, 0], [breaks[-1, 1]]))
             coefs = np.stack([pp.coef for pp in arr_poly])
             order = len(arr_poly[1].coef)
             dim = 1
@@ -434,7 +434,7 @@ class Sequence:
             vv = xs * coefs[index, 0]
             for i in range(1, order):
                 vv = xs * (vv + coefs[index, i])
-            last = np.cumsum(np.insert(vv, 0, 0)).reshape((-1, 1))
+            last = np.cumsum(np.concatenate(([0], vv))).reshape((-1, 1))
 
             coefs = np.hstack((coefs[:, :order], last))
             arr_poly_integ = []
@@ -1059,13 +1059,13 @@ class Sequence:
                     time = rf.t
                     signal = rf.signal
                     if abs(signal[0]) != 0:
-                        signal = np.insert(signal, obj=0, values=0)
-                        time = np.insert(time, obj=0, values=time[0])
+                        signal = np.concatenate(([0], signal))
+                        time = np.concatenate(([time[0]], time))
                         ic += 1
 
                     if abs(signal[-1]) != 0:
-                        signal = np.append(signal, 0)
-                        time = np.append(time, time[-1])
+                        signal = np.concatenate((signal, [0]))
+                        time = np.concatenate((time, [time[-1]]))
 
                     sp12.plot(t_factor * (t0 + time + rf.delay), np.abs(signal))
                     sp13.plot(
@@ -1619,8 +1619,8 @@ class Sequence:
                     adc_signal = np.exp(1j * adc.phase_offset) * np.exp(
                         1j * 2 * np.pi * t * adc.freq_offset
                     )
-                    adc_t_all = np.append(adc_t_all, adc_t)
-                    adc_signal_all = np.append(adc_signal_all, adc_signal)
+                    adc_t_all = np.concatenate((adc_t_all, adc_t))
+                    adc_signal_all = np.concatenate((adc_signal_all, adc_signal))
 
                 if hasattr(block, "rf"):
                     rf = block.rf
@@ -1642,10 +1642,10 @@ class Sequence:
                         * np.exp(1j * rf.phase_offset)
                         * np.exp(1j * 2 * math.pi * rf.t * rf.freq_offset)
                     )
-                    rf_t_all = np.append(rf_t_all, rf_t)
-                    rf_signal_all = np.append(rf_signal_all, rf)
-                    rf_t_centers = np.append(rf_t_centers, rf_t[ic])
-                    rf_signal_centers = np.append(rf_signal_centers, rf[ic])
+                    rf_t_all = np.concatenate((rf_t_all, rf_t))
+                    rf_signal_all = np.concatenate((rf_signal_all, rf))
+                    rf_t_centers = np.concatenate((rf_t_centers, [rf_t[ic]]))
+                    rf_signal_centers = np.concatenate((rf_signal_centers, [rf[ic]]))
 
                 grad_channels = ["gx", "gy", "gz"]
                 for x in range(
@@ -1678,14 +1678,14 @@ class Sequence:
                             g = 1e-3 * grad.amplitude * np.array([0, 0, 1, 1, 0])
 
                         if grad.channel == "x":
-                            gx_t_all = np.append(gx_t_all, g_t)
-                            gx_all = np.append(gx_all, g)
+                            gx_t_all = np.concatenate((gx_t_all, g_t))
+                            gx_all = np.concatenate((gx_all, g))
                         elif grad.channel == "y":
-                            gy_t_all = np.append(gy_t_all, g_t)
-                            gy_all = np.append(gy_all, g)
+                            gy_t_all = np.concatenate((gy_t_all, g_t))
+                            gy_all = np.concatenate((gy_all, g))
                         elif grad.channel == "z":
-                            gz_t_all = np.append(gz_t_all, g_t)
-                            gz_all = np.append(gz_all, g)
+                            gz_t_all = np.concatenate((gz_t_all, g_t))
+                            gz_all = np.concatenate((gz_all, g))
 
             t0 += self.arr_block_durations[
                 block_counter

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -24,6 +24,8 @@ from pypulseq.decompress_shape import decompress_shape
 from pypulseq.event_lib import EventLibrary
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_labels
+from pypulseq.utils.cumsum import cumsum
+
 from version import major, minor, revision
 
 
@@ -1094,15 +1096,13 @@ class Sequence:
                                 (grad.first, *grad.waveform, grad.last)
                             )
                         else:
-                            time = np.cumsum(
-                                [
+                            time = np.array(cumsum(
                                     0,
                                     grad.delay,
                                     grad.rise_time,
                                     grad.flat_time,
                                     grad.fall_time,
-                                ]
-                            )
+                            ))
                             waveform = (
                                 g_factor * grad.amplitude * np.array([0, 0, 1, 1, 0])
                             )
@@ -1449,15 +1449,11 @@ class Sequence:
                             out_len[j] += 4
                             _temp = np.vstack(
                                 (
-                                    curr_dur
-                                    + grad.delay
-                                    + np.cumsum(
-                                        [
-                                            0,
+                                    cumsum(
+                                            curr_dur + grad.delay,
                                             grad.rise_time,
                                             grad.flat_time,
                                             grad.fall_time,
-                                        ]
                                     ),
                                     grad.amplitude * np.array([0, 1, 1, 0]),
                                 )
@@ -1468,9 +1464,7 @@ class Sequence:
                                 out_len[j] += 3
                                 _temp = np.vstack(
                                     (
-                                        curr_dur
-                                        + grad.delay
-                                        + np.cumsum([0, grad.rise_time, grad.fall_time]),
+                                        cumsum(curr_dur + grad.delay, grad.rise_time, grad.fall_time),
                                         grad.amplitude * np.array([0, 1, 0]),
                                     )
                                 )
@@ -1674,14 +1668,12 @@ class Sequence:
                             )
                             g = 1e-3 * np.array((grad.first, *grad.waveform, grad.last))
                         else:  # Trapezoid gradient option
-                            g_t = t0 + np.cumsum(
-                                [
-                                    0,
+                            g_t = cumsum(
+                                    t0,
                                     grad.delay,
                                     grad.rise_time,
                                     grad.flat_time,
                                     grad.fall_time,
-                                ]
                             )
                             g = 1e-3 * grad.amplitude * np.array([0, 0, 1, 1, 0])
 

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -40,7 +40,7 @@ class Sequence:
     version_minor = minor
     version_revision = revision
 
-    def __init__(self, system=Opts()):
+    def __init__(self, system=Opts(), use_block_cache=True):
         # =========
         # EVENT LIBRARIES
         # =========
@@ -65,6 +65,8 @@ class Sequence:
         self.system = system
 
         self.block_events = OrderedDict()  # Event table
+        self.use_block_cache = use_block_cache
+        self.block_cache = dict()  # Block cache
         self.definitions = dict()  # Optional sequence definitions
 
         self.rf_raster_time = (

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -58,7 +58,7 @@ class Sequence:
             EventLibrary()
         )  # Library of Label(set) events (reference from the extensions library)
         self.rf_library = EventLibrary()  # Library of RF events
-        self.shape_library = EventLibrary()  # Library of compressed shapes
+        self.shape_library = EventLibrary(numpy_data=True)  # Library of compressed shapes
         self.trigger_library = EventLibrary()  # Library of trigger events
 
         # =========

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1091,7 +1091,7 @@ class Sequence:
                         if grad.type == "grad":
                             # We extend the shape by adding the first and the last points in an effort of making the
                             # display a bit less confusing...
-                            time = grad.delay + [0, *grad.tt, grad.shape_dur]
+                            time = grad.delay + np.array([0, *grad.tt, grad.shape_dur])
                             waveform = g_factor * np.array(
                                 (grad.first, *grad.waveform, grad.last)
                             )

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -323,7 +323,7 @@ class Sequence:
         for j in range(ng):
             wave_cnt = gw_data[j].shape[1]
             if wave_cnt == 0:
-                if np.abs(gradient_offset[j]) <= eps:
+                if abs(gradient_offset[j]) <= eps:
                     gw_pp.append(None)
                     gw_pp_MATLAB.append(None)
                     continue
@@ -333,7 +333,7 @@ class Sequence:
                 gw = gw_data[j]
 
             # Now gw contains the waveform from the current axis
-            if np.abs(gradient_delays[j]) > eps:
+            if abs(gradient_delays[j]) > eps:
                 gw[0] = gw[0] - gradient_delays[j]  # Anisotropic gradient delay support
             if not np.all(np.isfinite(gw)):
                 raise Warning("Not all elements of the generated waveform are finite.")
@@ -351,7 +351,7 @@ class Sequence:
                 _temp = np.array(([gw[0, -1] + teps, total_duration + teps], [0, 0]))
                 gw = np.hstack((gw, _temp))
 
-            if np.abs(gradient_offset[j]) > eps:
+            if abs(gradient_offset[j]) > eps:
                 gw[1,:] += gradient_offset[j]
 
             gw[1][gw[1] == -0.0] = 0.0
@@ -463,8 +463,8 @@ class Sequence:
                 for j in range(len(ii)):
                     res = (
                         np.arange(
-                            np.floor(float(res_breaks[ii[j]] / self.grad_raster_time)),
-                            np.ceil(
+                            math.floor(float(res_breaks[ii[j]] / self.grad_raster_time)),
+                            math.ceil(
                                 (res_breaks[ii[j] + 1] / self.grad_raster_time) + 1
                             ),
                         )
@@ -528,8 +528,8 @@ class Sequence:
                 continue
 
             it = np.where(np.logical_and(
-                t_ktraj >= t_acc * np.round(t_acc_inv * res_breaks[0]),
-                t_ktraj <= t_acc * np.round(t_acc_inv * res_breaks[-1]),
+                t_ktraj >= t_acc * round(t_acc_inv * res_breaks[0]),
+                t_ktraj <= t_acc * round(t_acc_inv * res_breaks[-1]),
             ))[0]
             k_traj[i, it] = self.ppval_MATLAB(gm_pp[i], t_ktraj[it])
             if t_ktraj[it[-1]] < t_ktraj[-1]:
@@ -541,9 +541,9 @@ class Sequence:
             i_period = i_periods[i]
             i_period_end = i_periods[i + 1]
             if ii_next_excitation >= 0 and i_excitation[ii_next_excitation] == i_period:
-                if np.abs(t_ktraj[i_period] - t_excitation[ii_next_excitation]) > t_acc:
+                if abs(t_ktraj[i_period] - t_excitation[ii_next_excitation]) > t_acc:
                     raise Warning(
-                        f"np.abs(t_ktraj[i_period]-t_excitation[ii_next_excitation]) < {t_acc} failed for ii_next_excitation={ii_next_excitation} error={t_ktraj(i_period) - t_excitation(ii_next_excitation)}"
+                        f"abs(t_ktraj[i_period]-t_excitation[ii_next_excitation]) < {t_acc} failed for ii_next_excitation={ii_next_excitation} error={t_ktraj(i_period) - t_excitation(ii_next_excitation)}"
                     )
                 dk = -k_traj[:, i_period]
                 if i_period > 0:
@@ -630,7 +630,7 @@ class Sequence:
             is_ok = is_ok and res
 
             # Check the stored total block duration
-            if np.abs(duration - self.block_durations[block_counter]) > eps:
+            if abs(duration - self.block_durations[block_counter]) > eps:
                 rep += "Inconsistency between the stored block duration and the duration of the block content"
                 is_ok = False
                 duration = self.block_durations[block_counter]
@@ -1054,12 +1054,12 @@ class Sequence:
                     tc, ic = calc_rf_center(rf)
                     time = rf.t
                     signal = rf.signal
-                    if np.abs(signal[0]) != 0:
+                    if abs(signal[0]) != 0:
                         signal = np.insert(signal, obj=0, values=0)
                         time = np.insert(time, obj=0, values=time[0])
                         ic += 1
 
-                    if np.abs(signal[-1]) != 0:
+                    if abs(signal[-1]) != 0:
                         signal = np.append(signal, 0)
                         time = np.append(time, time[-1])
 
@@ -1259,7 +1259,7 @@ class Sequence:
             compressed.data = shape_data[1:]
             rf.t = decompress_shape(compressed) * self.rf_raster_time
             rf.shape_dur = (
-                np.ceil((rf.t[-1] - eps) / self.rf_raster_time) * self.rf_raster_time
+                math.ceil((rf.t[-1] - eps) / self.rf_raster_time) * self.rf_raster_time
             )
         else:  # Generate default time raster on the fly
             rf.t = (np.arange(1, len(rf.signal) + 1) - 0.5) * self.rf_raster_time
@@ -1443,7 +1443,7 @@ class Sequence:
                                 ]
                             ))
                     else:
-                        if np.abs(grad.flat_time) > eps:
+                        if abs(grad.flat_time) > eps:
                             out_len[j] += 4
                             _temp = np.vstack(
                                 (
@@ -1462,7 +1462,7 @@ class Sequence:
                             )
                             shape_pieces[j].append(_temp)
                         else:
-                            if np.abs(grad.rise_time) > eps and np.abs(grad.fall_time) > eps:
+                            if abs(grad.rise_time) > eps and abs(grad.fall_time) > eps:
                                 out_len[j] += 3
                                 _temp = np.vstack(
                                     (
@@ -1474,7 +1474,7 @@ class Sequence:
                                 )
                                 shape_pieces[j].append(_temp)
                             else:
-                                if np.abs(grad.amplitude) > eps:
+                                if abs(grad.amplitude) > eps:
                                     print('Warning: "empty" gradient with non-zero magnitude detected in block {}'.format(block_counter))
 
             if block.rf is not None:  # RF
@@ -1505,12 +1505,12 @@ class Sequence:
                     )
                     out_len[-1] += len(rf.t)
 
-                    if np.abs(rf.signal[0]) > 0:
+                    if abs(rf.signal[0]) > 0:
                         pre = np.array([[rf_piece[0, 0] - 0.1*self.system.rf_raster_time], [0]])
                         rf_piece = np.hstack((pre, rf_piece))
                         out_len[-1] += pre.shape[1]
 
-                    if np.abs(rf.signal[-1]) > 0:
+                    if abs(rf.signal[-1]) > 0:
                         post = np.array([[rf_piece[0, -1] + 0.1*self.system.rf_raster_time], [0]])
                         rf_piece = np.hstack((rf_piece, post))
                         out_len[-1] += post.shape[1]

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -25,6 +25,7 @@ from pypulseq.event_lib import EventLibrary
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_labels
 from pypulseq.utils.cumsum import cumsum
+from pypulseq.block_to_events import block_to_events
 
 from version import major, minor, revision
 
@@ -629,7 +630,7 @@ class Sequence:
 
         for block_counter in range(num_blocks):
             block = self.get_block(block_counter + 1)
-            events = [e for e in vars(block).values() if e is not None]
+            events = block_to_events(block)
             res, rep, duration = ext_check_timing(self.system, *events)
             is_ok = is_ok and res
 

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -190,7 +190,7 @@ def write(self, file_name: str, create_signature) -> None:
             id_format_str = "{:.0f} {:.0f} {:.0f} {:.0f} {:.0f}\n"  # Refer lines 20-21
             for k in keys.values():
                 s = id_format_str.format(
-                    k, *np.round(self.trigger_library.data[k] * [1, 1, 1e6, 1e6])
+                    k, *np.round(self.trigger_library.data[k] * np.array([1, 1, 1e6, 1e6]))
                 )
                 output_file.write(s)
             output_file.write("\n")

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -67,9 +67,9 @@ def write(self, file_name: str, create_signature) -> None:
             block_duration = (
                 self.block_durations[block_counter] / self.block_duration_raster
             )
-            block_duration_rounded = int(np.round(block_duration))
+            block_duration_rounded = round(block_duration)
 
-            assert np.abs(block_duration_rounded - block_duration) < 1e-6
+            assert abs(block_duration_rounded - block_duration) < 1e-6
 
             s = id_format_str.format(
                 *(
@@ -96,7 +96,7 @@ def write(self, file_name: str, create_signature) -> None:
                 lib_data1 = self.rf_library.data[k][0:4]
                 lib_data2 = self.rf_library.data[k][5:7]
                 delay = (
-                    np.round(self.rf_library.data[k][4] / self.rf_raster_time)
+                    round(self.rf_library.data[k][4] / self.rf_raster_time)
                     * self.rf_raster_time
                     * 1e6
                 )
@@ -122,7 +122,7 @@ def write(self, file_name: str, create_signature) -> None:
                 s = id_format_str.format(
                     k,
                     *self.grad_library.data[k][:3],
-                    np.round(self.grad_library.data[k][3] * 1e6),
+                    round(self.grad_library.data[k][3] * 1e6),
                 )
                 output_file.write(s)
             output_file.write("\n")

--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 
 
@@ -9,7 +10,7 @@ def round_half_up(n, decimals=0):
     Avoid banker's rounding inconsistencies; from https://realpython.com/python-rounding/#rounding-half-up
     """
     multiplier = 10**decimals
-    return np.floor(np.abs(n) * multiplier + 0.5) / multiplier
+    return math.floor(abs(n) * multiplier + 0.5) / multiplier
 
 
 # =========

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -201,7 +201,7 @@ def add_gradients(
             # Stop for numpy.arange is not g.delay - common_delay - system.grad_raster_time like in Matlab
             # so as to include the endpoint
             t_delay = np.arange(0, g.delay - common_delay, step=system.grad_raster_time)
-            waveforms[ii] = np.insert(waveforms[ii], 0, t_delay)
+            waveforms[ii] = np.concatenate(([t_delay], waveforms[ii]))
 
         num_points = len(waveforms[ii])
         max_length = max(num_points, max_length)

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy, deepcopy
 from types import SimpleNamespace
 from typing import Iterable
 
@@ -8,6 +8,7 @@ from pypulseq import eps
 from pypulseq.calc_duration import calc_duration
 from pypulseq.make_arbitrary_grad import make_arbitrary_grad
 from pypulseq.make_extended_trapezoid import make_extended_trapezoid
+from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.points_to_waveform import points_to_waveform
 
@@ -37,9 +38,6 @@ def add_gradients(
     grad : SimpleNamespace
         Superimposition of gradient events from `grads`.
     """
-    # copy() to emulate pass-by-value; otherwise passed grad events are modified
-    grads = deepcopy(grads)
-
     if max_grad <= 0:
         max_grad = system.max_grad
     if max_slew <= 0:
@@ -48,11 +46,31 @@ def add_gradients(
     if len(grads) == 0:
         raise ValueError("No gradients specified")
     if len(grads) == 1:
-        return grads[0]
+        # Trapezoids only require a shallow copy
+        if grads[0].type == 'trap':
+            return copy(grads[0])
+        else:
+            return deepcopy(grads[0])
     
     # First gradient defines channel
     channel = grads[0].channel
 
+    # Check if we have a set of traps with the same timing
+    if all(g.type == 'trap' for g in grads):
+        cond1 = all(g.delay == grads[0].delay for g in grads)
+        cond2 = all(g.rise_time == grads[0].rise_time for g in grads)
+        cond3 = all(g.flat_time == grads[0].flat_time for g in grads)
+        cond4 = all(g.fall_time == grads[0].fall_time for g in grads)
+        
+        if cond1 and cond2 and cond3 and cond4:
+            return make_trapezoid(grads[0].channel,
+                                  amplitude=sum(g.amplitude for g in grads)+eps,
+                                  rise_time=grads[0].rise_time,
+                                  flat_time=grads[0].flat_time,
+                                  fall_time=grads[0].fall_time,
+                                  delay=grads[0].delay,
+                                  system=system)
+    
     # Find out the general delay of all gradients and other statistics
     delays, firsts, lasts, durs, is_trap, is_arb = [], [], [], [], [], []
     for ii in range(len(grads)):
@@ -69,26 +87,6 @@ def add_gradients(
         else:
             tt_rast = grads[ii].tt / system.grad_raster_time - 0.5
             is_arb.append(np.all(np.abs(tt_rast - np.arange(len(tt_rast)))) < eps)
-
-    # Convert to numpy.ndarray for fancy-indexing later on
-    firsts, lasts = np.array(firsts), np.array(lasts)
-
-    common_delay = np.min(delays)
-    total_duration = np.max(durs)
-
-    # Check if we have a set of traps with the same timing
-    if np.all(is_trap):
-        cond1 = 1 == len(np.unique([g.delay for g in grads]))
-        cond2 = 1 == len(np.unique([g.rise_time for g in grads]))
-        cond3 = 1 == len(np.unique([g.flat_time for g in grads]))
-        cond4 = 1 == len(np.unique([g.fall_time for g in grads]))
-        if cond1 and cond2 and cond3 and cond4:
-            grad = grads[0]
-            grad.amplitude = np.sum([g.amplitude for g in grads])
-            grad.area = np.sum([g.area for g in grads])
-            grad.flat_area = np.sum([g.flat_area for g in grads])
-
-            return grad
 
     # Check if we only have arbitrary grads on irregular time samplings, optionally mixed with trapezoids
     if np.all(np.logical_or(is_trap, np.logical_not(is_arb))):
@@ -119,13 +117,15 @@ def add_gradients(
             g = grads[ii]
             if g.type == "trap":
                 if g.flat_time > 0:  # Trapezoid or triangle
-                    g.tt = np.cumsum([0, g.rise_time, g.flat_time, g.fall_time])
-                    g.waveform = [0, g.amplitude, g.amplitude, 0]
+                    tt = np.cumsum([g.delay, g.rise_time, g.flat_time, g.fall_time])
+                    waveform = [0, g.amplitude, g.amplitude, 0]
                 else:
-                    g.tt = np.cumsum([0, g.rise_time, g.fall_time])
-                    g.waveform = [0, g.amplitude, 0]
+                    tt = np.cumsum([g.delay, g.rise_time, g.fall_time])
+                    waveform = [0, g.amplitude, 0]
+            else:
+                tt = g.delay + g.tt
+                waveform = g.waveform
 
-            tt = g.delay + g.tt
             # Fix rounding for the first and last time points
             i_min = np.argmin(np.abs(tt[0] - times))
             t_min = (np.abs(tt[0] - times))[i_min]
@@ -136,15 +136,20 @@ def add_gradients(
             if t_min < eps:
                 tt[-1] = times[i_min]
 
-            if abs(g.waveform[0]) > eps and tt[0] > eps:
+            if abs(waveform[0]) > eps and tt[0] > eps:
                 tt[0] += eps
 
-            amplitudes += np.interp(xp=tt, fp=g.waveform, x=times)
+            amplitudes += np.interp(xp=tt, fp=waveform, x=times)
 
         grad = make_extended_trapezoid(
             channel=channel, amplitudes=amplitudes, times=times, system=system
         )
         return grad
+    
+    # Convert to numpy.ndarray for fancy-indexing later on
+    firsts, lasts = np.array(firsts), np.array(lasts)
+    common_delay = np.min(delays)
+    durs = np.array(durs)
 
     # Convert everything to a regularly-sampled waveform
     waveforms = dict()
@@ -199,7 +204,7 @@ def add_gradients(
             waveforms[ii] = np.insert(waveforms[ii], 0, t_delay)
 
         num_points = len(waveforms[ii])
-        max_length = num_points if num_points > max_length else max_length
+        max_length = max(num_points, max_length)
 
     w = np.zeros(max_length)
     for ii in range(len(grads)):
@@ -217,8 +222,8 @@ def add_gradients(
     )
     # Fix the first and the last values
     # First is defined by the sum of firsts with the minimal delay (common_delay)
-    # Last is defined by the sum of lasts with the maximum duration (total_duration)
+    # Last is defined by the sum of lasts with the maximum duration (total_duration == durs.max())
     grad.first = np.sum(firsts[np.array(delays) == common_delay])
-    grad.last = np.sum(lasts[np.where(durs == total_duration)])
+    grad.last = np.sum(lasts[durs == durs.max()])
 
     return grad

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -136,7 +136,7 @@ def add_gradients(
             if t_min < eps:
                 tt[-1] = times[i_min]
 
-            if np.abs(g.waveform[0]) > eps and tt[0] > eps:
+            if abs(g.waveform[0]) > eps and tt[0] > eps:
                 tt[0] += eps
 
             amplitudes += np.interp(xp=tt, fp=g.waveform, x=times)

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -11,7 +11,7 @@ from pypulseq.make_extended_trapezoid import make_extended_trapezoid
 from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.points_to_waveform import points_to_waveform
-
+from pypulseq.utils.cumsum import cumsum
 
 def add_gradients(
     grads: Iterable[SimpleNamespace],
@@ -96,7 +96,7 @@ def add_gradients(
             g = grads[ii]
             if g.type == "trap":
                 times.extend(
-                    np.cumsum([g.delay, g.rise_time, g.flat_time, g.fall_time])
+                    cumsum(g.delay, g.rise_time, g.flat_time, g.fall_time)
                 )
             else:
                 times.extend(g.delay + g.tt)
@@ -117,10 +117,10 @@ def add_gradients(
             g = grads[ii]
             if g.type == "trap":
                 if g.flat_time > 0:  # Trapezoid or triangle
-                    tt = np.cumsum([g.delay, g.rise_time, g.flat_time, g.fall_time])
+                    tt = list(cumsum(g.delay, g.rise_time, g.flat_time, g.fall_time))
                     waveform = [0, g.amplitude, g.amplitude, 0]
                 else:
-                    tt = np.cumsum([g.delay, g.rise_time, g.fall_time])
+                    tt = list(cumsum(g.delay, g.rise_time, g.fall_time))
                     waveform = [0, g.amplitude, 0]
             else:
                 tt = g.delay + g.tt

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -56,20 +56,18 @@ def add_gradients(
     channel = grads[0].channel
 
     # Check if we have a set of traps with the same timing
-    if all(g.type == 'trap' for g in grads):
-        cond1 = all(g.delay == grads[0].delay for g in grads)
-        cond2 = all(g.rise_time == grads[0].rise_time for g in grads)
-        cond3 = all(g.flat_time == grads[0].flat_time for g in grads)
-        cond4 = all(g.fall_time == grads[0].fall_time for g in grads)
-        
-        if cond1 and cond2 and cond3 and cond4:
-            return make_trapezoid(grads[0].channel,
-                                  amplitude=sum(g.amplitude for g in grads)+eps,
-                                  rise_time=grads[0].rise_time,
-                                  flat_time=grads[0].flat_time,
-                                  fall_time=grads[0].fall_time,
-                                  delay=grads[0].delay,
-                                  system=system)
+    if (all(g.type == 'trap' for g in grads)
+            and all(g.rise_time == grads[0].rise_time for g in grads)
+            and all(g.flat_time == grads[0].flat_time for g in grads)
+            and all(g.fall_time == grads[0].fall_time for g in grads)
+            and all(g.delay == grads[0].delay for g in grads)):
+        return make_trapezoid(grads[0].channel,
+                              amplitude=sum(g.amplitude for g in grads)+eps,
+                              rise_time=grads[0].rise_time,
+                              flat_time=grads[0].flat_time,
+                              fall_time=grads[0].fall_time,
+                              delay=grads[0].delay,
+                              system=system)
     
     # Find out the general delay of all gradients and other statistics
     delays, firsts, lasts, durs, is_trap, is_arb = [], [], [], [], [], []

--- a/pypulseq/block_to_events.py
+++ b/pypulseq/block_to_events.py
@@ -16,27 +16,17 @@ def block_to_events(*args: SimpleNamespace) -> Tuple[SimpleNamespace, ...]:
     events : list[SimpleNamespace]
         List of events comprising `args` if it was a block, otherwise `args` unmodified.
     """
-    if (
-        len(args) == 1
-    ):  # args is a tuple consisting a block of events, or a single event
-        x = args[0]
-
-        if isinstance(x, (float, int)):  # args is block duration
-            events = [x]
-        else:  # args could be a block of events or a single event
-            events = list(vars(x).values())  # Get all attrs
-            events = list(
-                filter(lambda filter_none: filter_none is not None, events)
-            )  # Filter None attributes
-            # If all attrs are either float/SimpleNamespace, args is a block of events
-            if all([isinstance(e, (float, SimpleNamespace)) for e in events]):
-                events = __get_label_events_if_any(
-                    *events
-                )  # Flatten label events from dict datatype
-            else:  # Else, args is a single event
-                events = [x]
+    if len(args) == 1 and hasattr(args[0], 'rf'):
+        events = list(vars(args[0]).values())  # Get all attrs
+        events = list(
+            filter(lambda filter_none: filter_none is not None, events)
+        )  # Filter None attributes
+        events = __get_label_events_if_any(
+            *events
+        )  # Flatten label events from dict datatype
+        
     else:  # args is a tuple of events
-        events = __get_label_events_if_any(*args)
+        return args
 
     return events
 

--- a/pypulseq/calc_duration.py
+++ b/pypulseq/calc_duration.py
@@ -34,28 +34,24 @@ def calc_duration(*args: SimpleNamespace) -> float:
             )
 
         if event.type == "delay":
-            duration = np.max([duration, event.delay])
+            duration = max(duration, event.delay)
         elif event.type == "rf":
-            duration = np.max(
-                [duration, event.delay + event.shape_dur + event.ringdown_time]
+            duration = max(
+                duration, event.delay + event.shape_dur + event.ringdown_time
             )
         elif event.type == "grad":
-            duration = np.max([duration, event.delay + event.shape_dur])
+            duration = max(duration, event.delay + event.shape_dur)
         elif event.type == "adc":
-            duration = np.max(
-                [
+            duration = max(
                     duration,
                     event.delay + event.num_samples * event.dwell + event.dead_time,
-                ]
             )
         elif event.type == "trap":
-            duration = np.max(
-                [
+            duration = max(
                     duration,
                     event.delay + event.rise_time + event.flat_time + event.fall_time,
-                ]
             )
         elif event.type == "output" or event.type == "trigger":
-            duration = np.max([duration, event.delay + event.duration])
+            duration = max(duration, event.delay + event.duration)
 
     return duration

--- a/pypulseq/calc_ramp.py
+++ b/pypulseq/calc_ramp.py
@@ -345,7 +345,7 @@ def calc_ramp(
                 k0=k0, k_end=k_end, G0=G0, G_end=G_end, use_points=use_points
             )
         else:
-            if np.abs(G0) > np.abs(max_grad) or np.abs(G_end) > np.abs(max_grad):
+            if abs(G0) > abs(max_grad) or abs(G_end) > abs(max_grad):
                 break
             success, k_out = __joinleft1(
                 k0=k0, k_end=k_end, use_points=use_points, G0=G0, G_end=G_end

--- a/pypulseq/calc_rf_bandwidth.py
+++ b/pypulseq/calc_rf_bandwidth.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Union, Tuple
 
 import numpy as np
+import math
 
 from pypulseq.calc_rf_center import calc_rf_center
 
@@ -37,12 +38,12 @@ def calc_rf_bandwidth(
     # Resample the pulse to a reasonable time array
     dw = 10  # Hz
     dt = 1e-6  # For now, 1 MHz
-    nn = np.round(1 / dw / dt)
-    tt = np.arange(-np.floor(nn / 2), np.ceil(nn / 2) - 1) * dt
+    nn = round(1 / dw / dt)
+    tt = np.arange(-math.floor(nn / 2), math.ceil(nn / 2) - 1) * dt
 
     rfs = np.interp(xp=rf.t - time_center, fp=rf.signal, x=tt)
     spectrum = np.fft.fftshift(np.fft.fft(np.fft.fftshift(rfs)))
-    w = np.arange(-np.floor(nn / 2), np.ceil(nn / 2) - 1) * dw
+    w = np.arange(-math.floor(nn / 2), math.ceil(nn / 2) - 1) * dw
 
     w1 = __find_flank(w, spectrum, cutoff)
     w2 = __find_flank(w[::-1], spectrum[::-1], cutoff)

--- a/pypulseq/calc_rf_center.py
+++ b/pypulseq/calc_rf_center.py
@@ -26,6 +26,6 @@ def calc_rf_center(rf: SimpleNamespace) -> Tuple[float, float]:
     rf_max = np.max(np.abs(rf.signal))
     i_peak = np.where(np.abs(rf.signal) >= rf_max * 0.99999)[0]
     time_center = (rf.t[i_peak[0]] + rf.t[i_peak[-1]]) / 2
-    id_center = i_peak[int(np.round((len(i_peak) - 1) / 2))]
+    id_center = i_peak[round((len(i_peak) - 1) / 2)]
 
     return time_center, id_center

--- a/pypulseq/check_timing.py
+++ b/pypulseq/check_timing.py
@@ -73,8 +73,8 @@ def check_timing(system: Opts, *events: SimpleNamespace) -> Tuple[bool, str, flo
         if hasattr(e, "dwell"):
             if (
                 e.dwell < system.adc_raster_time
-                or np.abs(
-                    np.round(e.dwell / system.adc_raster_time) * system.adc_raster_time
+                or abs(
+                    round(e.dwell / system.adc_raster_time) * system.adc_raster_time
                     - e.dwell
                 )
                 > 1e-10
@@ -116,4 +116,4 @@ def __div_check(a: float, b: float) -> bool:
     Checks whether `a` can be divided by `b` to an accuracy of 1e-9.
     """
     c = a / b
-    return abs(c - np.round(c)) < 1e-9
+    return abs(c - round(c)) < 1e-9

--- a/pypulseq/compress_shape.py
+++ b/pypulseq/compress_shape.py
@@ -41,28 +41,25 @@ def compress_shape(
     quant_factor = 1e-7
     decompressed_shape_scaled = decompressed_shape / quant_factor
     datq = np.round(
-        np.insert(np.diff(decompressed_shape_scaled), 0, decompressed_shape_scaled[0])
+        np.concatenate((decompressed_shape_scaled[[0]], np.diff(decompressed_shape_scaled)))
     )
     qerr = decompressed_shape_scaled - np.cumsum(datq)
-    qcor = np.insert(np.diff(np.round(qerr)), 0, 0)
+    qcor = np.concatenate(([0], np.diff(np.round(qerr))))
     datd = datq + qcor
 
-    mask_changes = np.insert(np.asarray(np.diff(datd) != 0, dtype=np.int32), 0, 1)
-    # Elements without repetitions
-    vals = datd[mask_changes.nonzero()[0]] * quant_factor
-
-    # Indices of changes
-    k = np.append(mask_changes, 1).nonzero()[0]
-    # Number of repetitions
-    n = np.diff(k)
-
-    n_extra = (n - 2).astype(np.float32)  # Cast as float for nan assignment to work
-    vals2 = np.copy(vals)
-    vals2[n_extra < 0] = np.nan
-    n_extra[n_extra < 0] = np.nan
-    v = np.stack((vals, vals2, n_extra))
-    v = v.T[np.isfinite(v).T]  # Use transposes to match Matlab's Fortran indexing order
-    v[abs(v) < 1e-10] = 0
+    # RLE of datd
+    starts = np.concatenate(([0], np.flatnonzero(datd[1:] != datd[:-1])+1))
+    lengths = np.diff(np.concatenate((starts, [len(datd)])))
+    values = datd[starts] * quant_factor
+    
+    # Repeat values of any run-length>1 three times: (value, value, length)
+    rl_gt1 = lengths>1
+    repeats = 1 + rl_gt1*2
+    v = np.repeat(values, repeats)
+    
+    # Calculate indices of length elements and insert length values
+    inds = np.cumsum(repeats) - 1
+    v[inds[rl_gt1]] = lengths[rl_gt1] - 2
 
     compressed_shape = SimpleNamespace()
     compressed_shape.num_samples = len(decompressed_shape)

--- a/pypulseq/event_lib.py
+++ b/pypulseq/event_lib.py
@@ -34,19 +34,18 @@ class EventLibrary:
         Key-value pairs of data values and corresponding event keys.
     """
 
-    def __init__(self):
+    def __init__(self, numpy_data=False):
         self.keys = dict()
         self.data = dict()
-        self.lengths = dict()
         self.type = dict()
         self.keymap = dict()
         self.next_free_ID = 1
+        self.numpy_data = numpy_data
 
     def __str__(self) -> str:
         s = "EventLibrary:"
         s += "\nkeys: " + str(len(self.keys))
         s += "\ndata: " + str(len(self.data))
-        s += "\nlengths: " + str(len(self.lengths))
         s += "\ntype: " + str(len(self.type))
         return s
 
@@ -66,9 +65,11 @@ class EventLibrary:
         found : bool
             If `new_data` was found in the event library or not.
         """
-        if not isinstance(new_data, np.ndarray):
-            new_data = np.array(new_data)
-        key = new_data.tobytes()
+        if self.numpy_data:
+            new_data = np.asarray(new_data)
+            key = new_data.tobytes()
+        else:
+            key = tuple(new_data)
 
         if key in self.keymap:
             key_id = self.keymap[key]
@@ -102,9 +103,13 @@ class EventLibrary:
         found : bool
             If `new_data` was found in the event library or not.
         """
-        if not isinstance(new_data, np.ndarray):
-            new_data = np.array(new_data)
-        key = new_data.tobytes()
+        
+        if self.numpy_data:
+            new_data = np.asarray(new_data)
+            new_data.flags.writeable = False
+            key = new_data.tobytes()
+        else:
+            key = tuple(new_data)
 
         if key in self.keymap:
             key_id = self.keymap[key]
@@ -116,7 +121,6 @@ class EventLibrary:
             # Insert
             self.keys[key_id] = key_id
             self.data[key_id] = new_data
-            self.lengths[key_id] = max(new_data.shape)
 
             if data_type != str():
                 self.type[key_id] = data_type
@@ -152,14 +156,18 @@ class EventLibrary:
         if key_id == 0:
             key_id = self.next_free_ID
 
-        new_data = np.array(new_data)
+        if self.numpy_data:
+            new_data = np.asarray(new_data)
+            new_data.flags.writeable = False
+            key = new_data.tobytes()
+        else:
+            key = tuple(new_data)
+        
         self.keys[key_id] = key_id
         self.data[key_id] = new_data
-        self.lengths[key_id] = max(new_data.shape)
         if data_type != str():
             self.type[key_id] = data_type
-
-        key = new_data.tobytes()
+        
         self.keymap[key] = key_id
 
         if key_id >= self.next_free_ID:
@@ -181,7 +189,6 @@ class EventLibrary:
         return {
             "key": self.keys[key_id],
             "data": self.data[key_id],
-            "length": self.lengths[key_id],
             "type": self.type[key_id],
         }
 
@@ -202,7 +209,6 @@ class EventLibrary:
         out = SimpleNamespace()
         out.key = self.keys[key_id]
         out.data = self.data[key_id]
-        out.length = self.lengths[key_id]
         out.type = self.type[key_id]
 
         return out
@@ -223,9 +229,11 @@ class EventLibrary:
         data_type : str, default=str()
         """
         if len(self.keys) >= key_id:
-            if not isinstance(old_data, np.ndarray):
-                old_data = np.array(old_data)
-            key = old_data.tobytes()
+            if self.numpy_data:
+                old_data = np.asarray(old_data)
+                key = old_data.tobytes()
+            else:
+                key = tuple(old_data)
             del self.keymap[key]
 
         self.insert(key_id, new_data, data_type)

--- a/pypulseq/event_lib.py
+++ b/pypulseq/event_lib.py
@@ -66,7 +66,9 @@ class EventLibrary:
         found : bool
             If `new_data` was found in the event library or not.
         """
-        key = tuple(new_data)
+        if not isinstance(new_data, np.ndarray):
+            new_data = np.array(new_data)
+        key = new_data.tobytes()
 
         if key in self.keymap:
             key_id = self.keymap[key]
@@ -102,7 +104,7 @@ class EventLibrary:
         """
         if not isinstance(new_data, np.ndarray):
             new_data = np.array(new_data)
-        key = tuple(new_data)
+        key = new_data.tobytes()
 
         if key in self.keymap:
             key_id = self.keymap[key]
@@ -157,7 +159,7 @@ class EventLibrary:
         if data_type != str():
             self.type[key_id] = data_type
 
-        key = tuple(new_data)
+        key = new_data.tobytes()
         self.keymap[key] = key_id
 
         if key_id >= self.next_free_ID:
@@ -221,7 +223,9 @@ class EventLibrary:
         data_type : str, default=str()
         """
         if len(self.keys) >= key_id:
-            key = tuple(old_data)
+            if not isinstance(old_data, np.ndarray):
+                old_data = np.array(old_data)
+            key = old_data.tobytes()
             del self.keymap[key]
 
         self.insert(key_id, new_data, data_type)

--- a/pypulseq/make_adiabatic_pulse.py
+++ b/pypulseq/make_adiabatic_pulse.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Tuple, Union
 
 import numpy as np
+import math
 from sigpy.mri.rf import hypsec, wurst
 
 from pypulseq import eps
@@ -148,9 +149,9 @@ def make_adiabatic_pulse(
     if dwell == 0:
         dwell = system.rf_raster_time
 
-    n_raw = np.round(duration / dwell + eps)
+    n_raw = round(duration / dwell + eps)
     # Number of points must be divisible by 4 - requirement of sigpy.mri
-    N = np.floor(n_raw / 4) * 4
+    N = math.floor(n_raw / 4) * 4
 
     if pulse_type == "hypsec":
         am, fm = hypsec(n=N, beta=beta, mu=mu, dur=duration)
@@ -162,13 +163,13 @@ def make_adiabatic_pulse(
     pm = np.cumsum(fm) * dwell
 
     ifm = np.argmin(np.abs(fm))
-    dfm = np.abs(fm)[ifm]
+    dfm = abs(fm[ifm])
 
     # Find rate of change of frequency at the center of the pulse
     if dfm == 0:
         pm0 = pm[ifm]
         am0 = am[ifm]
-        roc_fm0 = np.abs(fm[ifm + 1] - fm[ifm - 1]) / 2 / dwell
+        roc_fm0 = abs(fm[ifm + 1] - fm[ifm - 1]) / 2 / dwell
     else:  # We need to bracket the zero-crossing
         if fm[ifm] * fm[ifm + 1] < 0:
             b = 1
@@ -177,7 +178,7 @@ def make_adiabatic_pulse(
 
         pm0 = (pm[ifm] * fm[ifm + b] - pm[ifm + b] * fm[ifm]) / (fm[ifm + b] - fm[ifm])
         am0 = (am[ifm] * fm[ifm + b] - am[ifm + b] * fm[ifm]) / (fm[ifm + b] - fm[ifm])
-        roc_fm0 = np.abs(fm[ifm] - fm[ifm + b]) / dwell
+        roc_fm0 = abs(fm[ifm] - fm[ifm + b]) / dwell
 
     pm -= pm0
     a = (roc_fm0 * adiabaticity) ** 0.5 / 2 / np.pi / am0
@@ -187,9 +188,9 @@ def make_adiabatic_pulse(
     if N != n_raw:
         n_pad = n_raw - N
         signal = [
-            np.zeros(1, n_pad - np.floor(n_pad / 2)),
+            np.zeros(1, n_pad - math.floor(n_pad / 2)),
             signal,
-            np.zeros(1, np.floor(n_pad / 2)),
+            np.zeros(1, math.floor(n_pad / 2)),
         ]
         N = n_raw
 
@@ -244,7 +245,7 @@ def make_adiabatic_pulse(
 
         if rf.delay > gz.rise_time:  # Round-up to gradient raster
             gz.delay = (
-                np.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
+                math.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
                 * system.grad_raster_time
             )
 

--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from typing import Tuple, Union
 
 import numpy as np
+import math
 
 from pypulseq import make_delay, calc_duration
 from pypulseq.make_trapezoid import make_trapezoid
@@ -136,7 +137,7 @@ def make_arbitrary_rf(
         if rf.delay > gz.rise_time:
             # Round-up to gradient raster
             gz.delay = (
-                np.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
+                math.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
                 * system.grad_raster_time
             )
 

--- a/pypulseq/make_block_pulse.py
+++ b/pypulseq/make_block_pulse.py
@@ -76,7 +76,7 @@ def make_block_pulse(
             raise ValueError("Either bandwidth or duration must be defined")
 
     BW = 1 / (4 * duration)
-    N = np.round(duration / system.rf_raster_time)
+    N = round(duration / system.rf_raster_time)
     t = np.array([0, N]) * system.rf_raster_time
     signal = flip_angle / (2 * np.pi) / duration * np.ones_like(t)
 

--- a/pypulseq/make_extended_trapezoid.py
+++ b/pypulseq/make_extended_trapezoid.py
@@ -80,8 +80,8 @@ def make_extended_trapezoid(
         )
 
     if (
-        np.abs(
-            np.round(times[-1] / system.grad_raster_time) * system.grad_raster_time
+        abs(
+            round(times[-1] / system.grad_raster_time) * system.grad_raster_time
             - times[-1]
         )
         > eps
@@ -130,11 +130,11 @@ def make_extended_trapezoid(
         grad.channel = channel
         grad.waveform = amplitudes
         grad.delay = (
-            np.round(times[0] / system.grad_raster_time) * system.grad_raster_time
+            round(times[0] / system.grad_raster_time) * system.grad_raster_time
         )
         grad.tt = times - grad.delay
         grad.shape_dur = (
-            np.round(times[-1] / system.grad_raster_time) * system.grad_raster_time
+            round(times[-1] / system.grad_raster_time) * system.grad_raster_time
         )
 
     grad.first = amplitudes[0]

--- a/pypulseq/make_extended_trapezoid_area.py
+++ b/pypulseq/make_extended_trapezoid_area.py
@@ -56,8 +56,8 @@ def make_extended_trapezoid_area(
     Gp = Gp[i_min]
     obj1val = obj1val[i_min]
 
-    if obj1val > 1e-3 or np.abs(Gp) > system.max_grad:  # Search did not converge
-        Gp = system.max_grad * np.sign(Gp)
+    if obj1val > 1e-3 or abs(Gp) > system.max_grad:  # Search did not converge
+        Gp = math.copysign(system.max_grad, Gp)
         obj2 = (
             lambda x: (
                 area
@@ -69,15 +69,15 @@ def make_extended_trapezoid_area(
         T, obj2val = *res2.x, res2.fun
         assert obj2val < 1e-2
 
-        Tp = np.ceil(T / system.grad_raster_time) * system.grad_raster_time
+        Tp = math.ceil(T / system.grad_raster_time) * system.grad_raster_time
 
         # Fix the ramps
         Tru = (
-            np.ceil(np.abs(Gp - grad_start) / SR / system.grad_raster_time)
+            math.ceil(abs(Gp - grad_start) / SR / system.grad_raster_time)
             * system.grad_raster_time
         )
         Trd = (
-            np.ceil(np.abs(Gp - grad_end) / SR / system.grad_raster_time)
+            math.ceil(abs(Gp - grad_end) / SR / system.grad_raster_time)
             * system.grad_raster_time
         )
         obj3 = lambda x: (area - __testGA1(x, Tru, Tp, Trd, grad_start, grad_end)) ** 2
@@ -93,11 +93,11 @@ def make_extended_trapezoid_area(
         amplitudes = [grad_start, Gp, Gp, grad_end]
     else:
         Tru = (
-            np.ceil(np.abs(Gp - grad_start) / SR / system.grad_raster_time)
+            math.ceil(abs(Gp - grad_start) / SR / system.grad_raster_time)
             * system.grad_raster_time
         )
         Trd = (
-            np.ceil(np.abs(Gp - grad_end) / SR / system.grad_raster_time)
+            math.ceil(abs(Gp - grad_end) / SR / system.grad_raster_time)
             * system.grad_raster_time
         )
 
@@ -117,14 +117,14 @@ def make_extended_trapezoid_area(
     )
     grad.area = __testGA1(Gp, Tru, Tp, Trd, grad_start, grad_end)
 
-    assert np.abs(grad.area - area) < 1e-3
+    assert abs(grad.area - area) < 1e-3
 
     return grad, times, amplitudes
 
 
 def __testGA(Gp, Tp, SR, dT, Gs, Ge):
-    Tru = np.ceil(np.abs(Gp - Gs) / SR / dT) * dT
-    Trd = np.ceil(np.abs(Gp - Ge) / SR / dT) * dT
+    Tru = math.ceil(abs(Gp - Gs) / SR / dT) * dT
+    Trd = math.ceil(abs(Gp - Ge) / SR / dT) * dT
     ga = __testGA1(Gp, Tru, Tp, Trd, Gs, Ge)
     return ga
 

--- a/pypulseq/make_extended_trapezoid_area.py
+++ b/pypulseq/make_extended_trapezoid_area.py
@@ -7,6 +7,7 @@ from scipy.optimize import minimize
 
 from pypulseq.make_extended_trapezoid import make_extended_trapezoid
 from pypulseq.opts import Opts
+from pypulseq.utils.cumsum import cumsum
 
 
 def make_extended_trapezoid_area(
@@ -89,7 +90,7 @@ def make_extended_trapezoid_area(
     assert Tp >= 0
 
     if Tp > 0:
-        times = np.cumsum([0, Tru, Tp, Trd])
+        times = cumsum(0, Tru, Tp, Trd)
         amplitudes = [grad_start, Gp, Gp, grad_end]
     else:
         Tru = (
@@ -103,13 +104,13 @@ def make_extended_trapezoid_area(
 
         if Trd > 0:
             if Tru > 0:
-                times = np.cumsum([0, Tru, Trd])
+                times = cumsum(0, Tru, Trd)
                 amplitudes = np.array([grad_start, Gp, grad_end])
             else:
-                times = np.cumsum([0, Trd])
+                times = cumsum(0, Trd)
                 amplitudes = np.array([grad_start, grad_end])
         else:
-            times = np.cumsum([0, Tru])
+            times = cumsum(0, Tru)
             amplitudes = np.array([grad_start, grad_end])
 
     grad = make_extended_trapezoid(
@@ -119,7 +120,7 @@ def make_extended_trapezoid_area(
 
     assert abs(grad.area - area) < 1e-3
 
-    return grad, times, amplitudes
+    return grad, np.array(times), amplitudes
 
 
 def __testGA(Gp, Tp, SR, dT, Gs, Ge):

--- a/pypulseq/make_gauss_pulse.py
+++ b/pypulseq/make_gauss_pulse.py
@@ -106,7 +106,7 @@ def make_gauss_pulse(
     else:
         BW = bandwidth
     alpha = apodization
-    N = int(np.round(duration / dwell))
+    N = round(duration / dwell)
     t = (np.arange(1, N + 1) - 0.5) * dwell
     tt = t - (duration * center_pos)
     window = 1 - alpha + alpha * np.cos(2 * np.pi * tt / duration)
@@ -153,7 +153,7 @@ def make_gauss_pulse(
 
         if rf.delay > gz.rise_time:
             gz.delay = (
-                np.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
+                math.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
                 * system.grad_raster_time
             )
 

--- a/pypulseq/make_sinc_pulse.py
+++ b/pypulseq/make_sinc_pulse.py
@@ -102,7 +102,7 @@ def make_sinc_pulse(
 
     BW = time_bw_product / duration
     alpha = apodization
-    N = int(np.round(duration / dwell))
+    N = round(duration / dwell)
     t = (np.arange(1, N + 1) - 0.5) * dwell
     tt = t - (duration * center_pos)
     window = 1 - alpha + alpha * np.cos(2 * np.pi * tt / duration)
@@ -150,7 +150,7 @@ def make_sinc_pulse(
 
         if rf.delay > gz.rise_time:
             gz.delay = (
-                np.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
+                math.ceil((rf.delay - gz.rise_time) / system.grad_raster_time)
                 * system.grad_raster_time
             )
 

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -1,12 +1,13 @@
 from types import SimpleNamespace
 
 import numpy as np
+import math
 
 from pypulseq.opts import Opts
 
 def calculate_shortest_params_for_area(area, max_slew, max_grad, grad_raster_time):
     rise_time = (
-        np.ceil(np.sqrt(np.abs(area) / max_slew) / grad_raster_time)
+        math.ceil(math.sqrt(abs(area) / max_slew) / grad_raster_time)
         * grad_raster_time
     )
     if rise_time < grad_raster_time:  # Area was almost 0 maybe
@@ -14,14 +15,14 @@ def calculate_shortest_params_for_area(area, max_slew, max_grad, grad_raster_tim
     amplitude = np.divide(area, rise_time)  # To handle nan
     t_eff = rise_time
 
-    if np.abs(amplitude) > max_grad:
+    if abs(amplitude) > max_grad:
         t_eff = (
-            np.ceil(np.abs(area) / max_grad / grad_raster_time)
+            math.ceil(abs(area) / max_grad / grad_raster_time)
             * grad_raster_time
         )
         amplitude = area / t_eff
         rise_time = (
-            np.ceil(np.abs(amplitude) / max_slew / grad_raster_time)
+            math.ceil(abs(amplitude) / max_slew / grad_raster_time)
             * grad_raster_time
         )
 
@@ -134,9 +135,9 @@ def make_trapezoid(
             amplitude2 = flat_area / flat_time
 
         if rise_time == 0:
-            rise_time = np.abs(amplitude2) / max_slew
+            rise_time = abs(amplitude2) / max_slew
             rise_time = (
-                np.ceil(rise_time / system.grad_raster_time) * system.grad_raster_time
+                math.ceil(rise_time / system.grad_raster_time) * system.grad_raster_time
             )
             if rise_time == 0:
                 rise_time = system.grad_raster_time
@@ -149,28 +150,28 @@ def make_trapezoid(
                 min_duration = rise_time + flat_time + fall_time
                 assert duration >= min_duration, (
                     f"Requested area is too large for this gradient. Minimum required duration is "
-                    f"{np.round(min_duration * 1e6)} uss"
+                    f"{round(min_duration * 1e6)} uss"
                 )
                 
-                dC = 1 / np.abs(2 * max_slew) + 1 / np.abs(2 * max_slew)
+                dC = 1 / abs(2 * max_slew) + 1 / abs(2 * max_slew)
                 amplitude2 = (
-                    duration - np.sqrt(duration**2 - 4 * np.abs(area) * dC)
+                    duration - math.sqrt(duration**2 - 4 * abs(area) * dC)
                 ) / (2 * dC)
             else:
                 if fall_time == 0:
                     fall_time = rise_time
                 amplitude2 = area / (duration - 0.5 * rise_time - 0.5 * fall_time)
                 possible = (
-                    duration >= (rise_time + fall_time) and np.abs(amplitude2) <= max_grad
+                    duration >= (rise_time + fall_time) and abs(amplitude2) <= max_grad
                 )
                 assert possible, (
                     f"Requested area is too large for this gradient. Probably amplitude is violated "
-                    f"{np.round(np.abs(amplitude) / max_grad * 100)}"
+                    f"{round(abs(amplitude) / max_grad * 100)}"
                 )
 
         if rise_time == 0:
             rise_time = (
-                np.ceil(np.abs(amplitude2) / max_slew / system.grad_raster_time)
+                math.ceil(abs(amplitude2) / max_slew / system.grad_raster_time)
                 * system.grad_raster_time
             )
             if rise_time == 0:
@@ -191,7 +192,7 @@ def make_trapezoid(
             amplitude2, rise_time, flat_time, fall_time = calculate_shortest_params_for_area(area, max_slew, max_grad, system.grad_raster_time)
 
 
-    if np.abs(amplitude2) > max_grad:
+    if abs(amplitude2) > max_grad:
         raise ValueError("Amplitude violation.")
 
     grad = SimpleNamespace()

--- a/pypulseq/points_to_waveform.py
+++ b/pypulseq/points_to_waveform.py
@@ -31,8 +31,8 @@ def points_to_waveform(
 
     grd = (
         np.arange(
-            start=np.round(np.min(times) / grad_raster_time),
-            stop=np.round(np.max(times) / grad_raster_time),
+            start=round(np.min(times) / grad_raster_time),
+            stop=round(np.max(times) / grad_raster_time),
         )
         * grad_raster_time
     )

--- a/pypulseq/rotate.py
+++ b/pypulseq/rotate.py
@@ -10,7 +10,7 @@ from pypulseq.opts import Opts
 
 def __get_grad_abs_mag(grad: SimpleNamespace) -> np.ndarray:
     if grad.type == "trap":
-        return np.abs(grad.amplitude)
+        return abs(grad.amplitude)
     return np.max(np.abs(grad.waveform))
 
 
@@ -76,7 +76,7 @@ def rotate(
     max_mag = 0  # Measure of relevant amplitude
     for i in range(len(i_rotate1)):
         g = args[i_rotate1[i]]
-        max_mag = np.max((max_mag, __get_grad_abs_mag(g)))
+        max_mag = max(max_mag, __get_grad_abs_mag(g))
         rotated1.append(scale_grad(grad=g, scale=np.cos(angle)))
         g = scale_grad(grad=g, scale=np.sin(angle))
         g.channel = axes_to_rotate[1]
@@ -84,7 +84,7 @@ def rotate(
 
     for i in range(len(i_rotate2)):
         g = args[i_rotate2[i]]
-        max_mag = np.max((max_mag, __get_grad_abs_mag(g)))
+        max_mag = max(max_mag, __get_grad_abs_mag(g))
         rotated2.append(scale_grad(grad=g, scale=np.cos(angle)))
         g = scale_grad(grad=g, scale=-np.sin(angle))
         g.channel = axes_to_rotate[0]

--- a/pypulseq/split_gradient.py
+++ b/pypulseq/split_gradient.py
@@ -46,10 +46,10 @@ def split_gradient(
 
     if grad.type == "trap":
         channel = grad.channel
-        grad.delay = np.round(grad.delay / grad_raster_time) * grad_raster_time
-        grad.rise_time = np.round(grad.rise_time / grad_raster_time) * grad_raster_time
-        grad.flat_time = np.round(grad.flat_time / grad_raster_time) * grad_raster_time
-        grad.fall_time = np.round(grad.fall_time / grad_raster_time) * grad_raster_time
+        grad.delay = round(grad.delay / grad_raster_time) * grad_raster_time
+        grad.rise_time = round(grad.rise_time / grad_raster_time) * grad_raster_time
+        grad.flat_time = round(grad.flat_time / grad_raster_time) * grad_raster_time
+        grad.fall_time = round(grad.fall_time / grad_raster_time) * grad_raster_time
 
         times = np.array([0, grad.rise_time])
         amplitudes = np.array([0, grad.amplitude])

--- a/pypulseq/split_gradient_at.py
+++ b/pypulseq/split_gradient_at.py
@@ -109,7 +109,7 @@ def split_gradient_at(
 
     # If the split line goes through the delay
     if time_point < grad.delay:
-        times = np.insert(grad.delay + times, 0, 0)
+        times = np.concatenate(([0], grad.delay + times))
         amplitudes = [0, amplitudes]
         grad.delay = 0
     else:
@@ -121,10 +121,10 @@ def split_gradient_at(
     # Sample at time point
     amp_tp = np.interp(x=time_point, xp=times, fp=amplitudes)
     t_eps = 1e-10
-    times1 = np.append(times[np.where(times < time_point - t_eps)], time_point)
-    amplitudes1 = np.append(amplitudes[np.where(times < time_point - t_eps)], amp_tp)
-    times2 = np.insert(times[times > time_point + t_eps], 0, time_point) - time_point
-    amplitudes2 = np.insert(amplitudes[times > time_point + t_eps], 0, amp_tp)
+    times1 = np.concatenate((times[np.where(times < time_point - t_eps)], [time_point]))
+    amplitudes1 = np.concatenate((amplitudes[np.where(times < time_point - t_eps)], [amp_tp]))
+    times2 = np.concatenate(([time_point], times[times > time_point + t_eps])) - time_point
+    amplitudes2 = np.concatenate(([amp_tp], amplitudes[times > time_point + t_eps]))
 
     # Recreate gradients
     grad1 = make_extended_trapezoid(

--- a/pypulseq/split_gradient_at.py
+++ b/pypulseq/split_gradient_at.py
@@ -49,15 +49,15 @@ def split_gradient_at(
 
     grad_raster_time = system.grad_raster_time
 
-    time_index = np.round(time_point / grad_raster_time)
+    time_index = round(time_point / grad_raster_time)
     # Work around floating-point arithmetic limitation
-    time_point = np.round(time_index * grad_raster_time, 6)
+    time_point = round(time_index * grad_raster_time, 6)
     channel = grad.channel
 
     if grad.type == "grad":
         # Check if we have an arbitrary gradient or an extended trapezoid
-        if np.abs(grad.tt[-1] - 0.5 * grad_raster_time) < 1e-10 and np.all(
-            np.abs(grad.tt[1:] - grad.tt[:-1] - grad_raster_time) < 1e-10
+        if abs(grad.tt[-1] - 0.5 * grad_raster_time) < 1e-10 and np.all(
+            abs(grad.tt[1:] - grad.tt[:-1] - grad_raster_time) < 1e-10
         ):
             # Arbitrary gradient -- trivial conversion
             # If time point is out of range we have nothing to do
@@ -81,10 +81,10 @@ def split_gradient_at(
             times = grad.tt
             amplitudes = grad.waveform
     elif grad.type == "trap":
-        grad.delay = np.round(grad.delay / grad_raster_time) * grad_raster_time
-        grad.rise_time = np.round(grad.rise_time / grad_raster_time) * grad_raster_time
-        grad.flat_time = np.round(grad.flat_time / grad_raster_time) * grad_raster_time
-        grad.fall_time = np.round(grad.fall_time / grad_raster_time) * grad_raster_time
+        grad.delay = round(grad.delay / grad_raster_time) * grad_raster_time
+        grad.rise_time = round(grad.rise_time / grad_raster_time) * grad_raster_time
+        grad.flat_time = round(grad.flat_time / grad_raster_time) * grad_raster_time
+        grad.fall_time = round(grad.fall_time / grad_raster_time) * grad_raster_time
 
         # Prepare the extended trapezoid structure
         if grad.flat_time == 0:

--- a/pypulseq/utils/cumsum.py
+++ b/pypulseq/utils/cumsum.py
@@ -1,0 +1,17 @@
+# Native Python cumsum for 2 to 5 elements
+# e.g.: cumsum(1,2,3) == (1,3,6)
+def cumsum(a, b, c=None, d=None, e=None):
+    if e != None:
+        s1 = a + b
+        s2 = s1 + c
+        s3 = s2 + d
+        return (a, s1, s2, s3, s3 + e)
+    elif d != None:
+        s1 = a + b
+        s2 = s1 + c
+        return (a, s1, s2, s2 + d)
+    elif c != None:
+        s = a + b
+        return (a, s, s + c)
+    else:
+        return (a, a + b)


### PR DESCRIPTION
- Replaced various calls to Numpy functions to native Python alternatives as this is much faster on scalar values and small lists (e.g. `max(a,b)` instead of `np.max([a,b])`).
- Replaced `np.cumsum` calls that used small, newly constructed lists with a native Python `cumsum`, specialized for up to 5 values (the maximum use-case found in pypulseq).
- Added caching of `get_block` to prevent expensive recalculations when blocks are repeatedly accessed.
- Replaced string-type dictionary keys with tuples in `event_lib` and `test_report`. This also fixes a bug where `event_lib.find_or_insert` would not find an existing event because a different key was used.
- Made `event_lib.find` use `next_free_ID` instead of recalculating this value every time.
- Optimized `compress_shape`, `add_gradients`, and `test_report`.

Overall performance improvements range from modest to 3-4x faster, depending on the type of sequence, and whether additional functions like `test_report` are used.

The `event_lib.find_or_insert` bug means that the produced `.seq` files after this PR are not identical to `dev`, as duplicated events are now not there, changing event id's along with it. But other than that, as far as I could tell the changes do not break anything. It would be helpful to check this with the unit tests (should the sequence files produced by MATLAB be included in the repository to make this easier?).