### PR TITLE
change sigpy dependency to GitHub repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "matplotlib>=3.5.2",
         "numpy>=1.19.5",
         "scipy>=1.8.1",
-        "sigpy==0.1.23",
+        "sigpy@git+https://github.com/mikgroup/sigpy",  # change before release to PyPI
     ],
     license="License :: OSI Approved :: GNU Affero General Public License v3",
     long_description=_get_long_description(),


### PR DESCRIPTION
This is a temporary fix to solve issue #119 resulting from the use of deprecated dtypes in the [sigpy ](https://github.com/mikgroup/sigpy) package.

It is a known issue in sigpy (https://github.com/mikgroup/sigpy/issues/123, https://github.com/mikgroup/sigpy/issues/124, https://github.com/mikgroup/sigpy/issues/129) that was been fixed (https://github.com/mikgroup/sigpy/pull/126) in their main branch, but it has not been released yet.

When a new sigpy version is released, we should change it back!

After merging this PR, it is possible to install a working version of pypulseq using:
`pip install git+https://github.com/imr-framework/pypulseq`