### PR TITLE
Reworked piecewise polynomial implementation in Sequence to use scipy's PPoly

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -225,7 +225,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                 "A gradient that doesn't end at zero needs to be aligned to the block boundary."
             )
 
-    self.block_durations.append(float(duration))
+    self.block_durations[block_index] = float(duration)
 
 
 def get_block(self, block_index: int) -> SimpleNamespace:
@@ -398,7 +398,7 @@ def get_block(self, block_index: int) -> SimpleNamespace:
 
             next_ext_id = ext_data[2]
 
-    block.block_duration = self.block_durations[block_index - 1]
+    block.block_duration = self.block_durations[block_index]
 
     # Enter block into the block cache
     if self.use_block_cache:

--- a/pypulseq/Sequence/ext_test_report.py
+++ b/pypulseq/Sequence/ext_test_report.py
@@ -30,7 +30,8 @@ def ext_test_report(self) -> str:
     # Calculate TE, TR
     duration, num_blocks, event_count = self.duration()
 
-    k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc = self.calculate_kspacePP()
+    k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc = self.calculate_kspace()
+    t_excitation = np.asarray(t_excitation)
 
     k_abs_adc = np.sqrt(np.sum(np.square(k_traj_adc), axis=0))
     k_abs_echo, index_echo = np.min(k_abs_adc), np.argmin(k_abs_adc)
@@ -137,9 +138,7 @@ def ext_test_report(self) -> str:
     else:
         unique_k_positions = 1
 
-    # gw_data = self.gradient_waveforms()
-    waveforms_and_times = self.waveforms_and_times()
-    gw_data = waveforms_and_times[0]
+    gw_data = self.waveforms()
     gws = [np.zeros_like(x) for x in gw_data]
     ga = np.zeros(len(gw_data))
     gs = np.zeros(len(gw_data))

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -248,17 +248,17 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
                 self.grad_library.lengths[i] += 1
 
         # For versions prior to 1.4.0 block_durations have not been initialized
-        self.block_durations = np.zeros(len(self.block_events))
+        self.block_durations = dict()
         # Scan through blocks and calculate durations
         for block_counter in range(len(self.block_events)):
             block = self.get_block(block_counter + 1)
-            if delay_ind_temp[block_counter] > 0:
+            if delay_ind_temp[block_counter + 1] > 0:
                 block.delay = SimpleNamespace()
                 block.delay.type = "delay"
                 block.delay.delay = temp_delay_library.data[
-                    delay_ind_temp[block_counter]
+                    delay_ind_temp[block_counter + 1]
                 ]
-            self.block_durations[block_counter] = calc_duration(block)
+            self.block_durations[block_counter + 1] = calc_duration(block)
 
     grad_channels = ["gx", "gy", "gz"]
     grad_prev_last = np.zeros(len(grad_channels))
@@ -435,8 +435,8 @@ def __read_blocks(
         Delay IDs.
     """
     event_table = dict()
-    block_durations = []
-    delay_idx = []
+    block_durations = dict()
+    delay_idx = dict()
     line = __strip_line(input_file)
 
     while line != "" and line != "#":
@@ -449,15 +449,9 @@ def __read_blocks(
 
         delay_id = block_events[0]
         if version_combined >= 1004000:
-            if delay_id > len(block_durations):
-                block_durations.append(block_events[1] * block_duration_raster)
-            else:
-                block_durations[delay_id] = block_events[1] * block_duration_raster
+            block_durations[delay_id] = block_events[1] * block_duration_raster
         else:
-            if delay_id > len(delay_idx):
-                delay_idx.append(block_events[1])
-            else:
-                delay_idx[delay_id] = block_events[1]
+            delay_idx[delay_id] = block_events[1]
 
         line = __strip_line(input_file)
 

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 import matplotlib as mpl
 import numpy as np
+from scipy.interpolate import PPoly
 from matplotlib import pyplot as plt
 
 from pypulseq import eps
@@ -109,6 +110,57 @@ class Sequence:
         s += "\nblock_events: " + str(len(self.block_events))
         return s
 
+    def adc_times(
+        self, time_range: List[float] = None
+    ) -> Tuple[List[float], np.ndarray, List[float], np.ndarray, np.ndarray]:
+        """
+        Return time points of ADC sampling points.
+
+        Returns
+        -------
+        t_adc: np.ndarray
+            Contains times of all ADC sample points.
+        fp_adc : np.ndarray
+            Contains frequency and phase offsets of each ADC object (not samples).
+        """
+
+        num_blocks = len(self.block_events)
+
+        # Collect ADC timing data
+        t_adc = []
+        fp_adc = []
+
+        curr_dur = 0
+
+        if time_range == None:
+            begin_block = 0
+            end_block = num_blocks
+        else:
+            if len(time_range) != 2:
+                raise ValueError('Time range must be list of two elements')
+            
+            t = np.cumsum(self.block_durations)
+            begin_block = np.searchsorted(t, time_range[0])
+            end_block = np.searchsorted(t - self.block_durations, time_range[1], side='right')
+
+        for block_counter in range(begin_block, end_block):
+            block = self.get_block(block_counter + 1)
+            
+            if block.adc is not None:  # ADC
+                t_adc.append(
+                    (np.arange(block.adc.num_samples) + 0.5) * block.adc.dwell
+                    + block.adc.delay
+                    + curr_dur
+                )
+                fp_adc.append([block.adc.freq_offset, block.adc.phase_offset])
+
+            curr_dur += self.block_durations[block_counter]
+
+        t_adc = np.concatenate(t_adc)
+        fp_adc = np.array(fp_adc)
+
+        return t_adc, fp_adc
+
     def add_block(self, *args: SimpleNamespace) -> None:
         """
         Add a new block/multiple events to the sequence. Adds a sequence block with provided as a block structure
@@ -125,162 +177,21 @@ class Sequence:
             Block structure or events to be added as a block to `Sequence`.
         """
         block.set_block(self, len(self.block_events) + 1, *args)
-
+            
     def calculate_kspace(
-        self, trajectory_delay: int = 0
-    ) -> Tuple[np.array, np.array, np.array, np.array, np.array]:
-        """
-        Calculates the k-space trajectory of the entire pulse sequence.
-
-        Parameters
-        ----------
-        trajectory_delay : int, default=0
-            Compensation factor in seconds (s) to align ADC and gradients in the reconstruction.
-
-        Returns
-        -------
-        k_traj_adc : numpy.array
-            K-space trajectory sampled at `t_adc` timepoints.
-        k_traj : numpy.array
-            K-space trajectory of the entire pulse sequence.
-        t_excitation : numpy.array
-            Excitation timepoints.
-        t_refocusing : numpy.array
-            Refocusing timepoints.
-        t_adc : numpy.array
-            Sampling timepoints.
-        """
-        if np.any(np.abs(trajectory_delay) > 100e-6):
-            raise Warning(
-                f"Trajectory delay of {trajectory_delay * 1e6} us is suspiciously high"
-            )
-
-        # Initialise the counters and accumulator objects
-        count_excitation = 0
-        count_refocusing = 0
-        count_adc_samples = 0
-
-        # Loop through the blocks to prepare preallocations
-        for block_counter in range(len(self.block_events)):
-            block = self.get_block(block_counter + 1)
-            if block.rf is not None:
-                if (
-                    not hasattr(block.rf, "use")
-                    or block.rf.use == "excitation"
-                    or block.rf.use == "undefined"
-                ):
-                    count_excitation += 1
-                elif block.rf.use == "refocusing":
-                    count_refocusing += 1
-
-            if block.adc is not None:
-                count_adc_samples += int(block.adc.num_samples)
-
-        t_excitation = np.zeros(count_excitation)
-        t_refocusing = np.zeros(count_refocusing)
-        k_time = np.zeros(count_adc_samples)
-        current_duration = 0
-        count_excitation = 0
-        count_refocusing = 0
-        kc_outer = 0
-        traj_recon_delay = trajectory_delay
-
-        # Go through the blocks and collect RF and ADC timing data
-        for block_counter in range(len(self.block_events)):
-            block = self.get_block(block_counter + 1)
-
-            if block.rf is not None:
-                rf = block.rf
-                rf_center, _ = calc_rf_center(rf)
-                t = rf.delay + rf_center
-                if (
-                    not hasattr(block.rf, "use")
-                    or block.rf.use == "excitation"
-                    or block.rf.use == "undefined"
-                ):
-                    t_excitation[count_excitation] = current_duration + t
-                    count_excitation += 1
-                elif block.rf.use == "refocusing":
-                    t_refocusing[count_refocusing] = current_duration + t
-                    count_refocusing += 1
-
-            if block.adc is not None:
-                _k_time = np.arange(block.adc.num_samples) + 0.5
-                _k_time = (
-                    _k_time * block.adc.dwell
-                    + block.adc.delay
-                    + current_duration
-                    + traj_recon_delay
-                )
-                k_time[kc_outer : kc_outer + block.adc.num_samples] = _k_time
-                kc_outer += block.adc.num_samples
-            current_duration += self.block_durations[block_counter]
-
-        # Now calculate the actual k-space trajectory based on the gradient waveforms
-        gw = self.gradient_waveforms()
-        i_excitation = np.round(t_excitation / self.grad_raster_time)
-        i_refocusing = np.round(t_refocusing / self.grad_raster_time)
-        i_periods = np.sort(
-            [1, *(i_excitation + 1), *(i_refocusing + 1), gw.shape[1] + 1]
-        ).astype(np.int32)
-        # i_periods -= 1  # Python is 0-indexed
-        ii_next_excitation = np.min((len(i_excitation), 1))
-        ii_next_refocusing = np.min((len(i_refocusing), 1))
-        k_traj = np.zeros_like(gw)
-        k = np.zeros((3, 1))
-
-        for i in range(len(i_periods) - 1):
-            i_period_end = i_periods[i + 1] - 1
-            k_period = np.concatenate(
-                (k, gw[:, i_periods[i] - 1 : i_period_end] * self.grad_raster_time),
-                axis=1,
-            )
-            k_period = np.cumsum(k_period, axis=1)
-            k_traj[:, i_periods[i] - 1 : i_period_end] = k_period[:, 1:]
-            k = k_period[:, -1]
-
-            if (
-                ii_next_excitation > 0
-                and i_excitation[ii_next_excitation - 1] == i_period_end
-            ):
-                k[:] = 0
-                k_traj[:, i_period_end - 1] = np.nan
-                ii_next_excitation = min(len(i_excitation), ii_next_excitation + 1)
-
-            if (
-                ii_next_refocusing > 0
-                and i_refocusing[ii_next_refocusing - 1] == i_period_end
-            ):
-                k = -k
-                ii_next_refocusing = min(len(i_refocusing), ii_next_refocusing + 1)
-
-            k = k.reshape((-1, 1))  # To be compatible with np.concatenate
-
-        k_traj_adc = []
-        for _k_traj_row in k_traj:
-            result = np.interp(
-                xp=np.array(range(1, k_traj.shape[1] + 1)) * self.grad_raster_time,
-                fp=_k_traj_row,
-                x=k_time,
-            )
-            k_traj_adc.append(result)
-        k_traj_adc = np.stack(k_traj_adc)
-        t_adc = k_time
-
-        return k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc
-
-    def calculate_kspacePP(
         self,
-        trajectory_delay: Union[int, float, np.ndarray] = 0,
-        gradient_offset: int = 0,
-    ) -> Tuple[np.array, np.array, np.array, np.array, np.array]:
+        trajectory_delay: Union[float, List[float], np.ndarray] = 0,
+        gradient_offset: Union[float, List[float], np.ndarray] = 0
+    ) -> Tuple[np.array, np.array, List[float], List[float], np.array]:
         """
         Calculates the k-space trajectory of the entire pulse sequence.
 
         Parameters
         ----------
-        trajectory_delay : int, default=0
+        trajectory_delay : float or list, default=0
             Compensation factor in seconds (s) to align ADC and gradients in the reconstruction.
+        gradient_offset : float or list, default=0
+            Simulates background gradients (specified in Hz/m)
 
         Returns
         -------
@@ -288,9 +199,9 @@ class Sequence:
             K-space trajectory sampled at `t_adc` timepoints.
         k_traj : numpy.array
             K-space trajectory of the entire pulse sequence.
-        t_excitation : numpy.array
+        t_excitation : List[float]
             Excitation timepoints.
-        t_refocusing : numpy.array
+        t_refocusing : List[float]
             Refocusing timepoints.
         t_adc : numpy.array
             Sampling timepoints.
@@ -300,195 +211,63 @@ class Sequence:
                 f"Trajectory delay of {trajectory_delay * 1e6} us is suspiciously high"
             )
 
-        total_duration = np.sum(self.block_durations)
+        total_duration = sum(self.block_durations)
 
-        gw_data, tfp_excitation, tfp_refocusing, t_adc, _ = self.waveforms_and_times()
-
-        ng = len(gw_data)
-        # Gradient delay handling
-        if isinstance(trajectory_delay, (int, float)):
-            gradient_delays = [trajectory_delay] * ng
-        else:
-            assert (
-                len(trajectory_delay) == ng
-            )  # Need to have same number of gradient channels
-            gradient_delays = [trajectory_delay] * ng
-
-        # Gradient offset handling
-        if isinstance(gradient_offset, (int, float)):
-            gradient_offset = [gradient_offset] * ng
-        else:
-            assert (
-                len(gradient_offset) == ng
-            )  # Need to have same number of gradient channels
+        t_excitation, fp_excitation, t_refocusing, _ = self.rf_times()
+        t_adc, _ = self.adc_times()
 
         # Convert data to piecewise polynomials
-        gw_pp = []
-        gw_pp_MATLAB = []
-        for j in range(ng):
-            wave_cnt = gw_data[j].shape[1]
-            if wave_cnt == 0:
-                if abs(gradient_offset[j]) <= eps:
-                    gw_pp.append(None)
-                    gw_pp_MATLAB.append(None)
-                    continue
-                else:
-                    gw = np.array(([0, total_duration], [0, 0]))
-            else:
-                gw = gw_data[j]
-
-            # Now gw contains the waveform from the current axis
-            if abs(gradient_delays[j]) > eps:
-                gw[0] = gw[0] - gradient_delays[j]  # Anisotropic gradient delay support
-            if not np.all(np.isfinite(gw)):
-                raise Warning("Not all elements of the generated waveform are finite.")
-
-            teps = 1e-12
-            if gw[0, 0] > 0 and gw[0, -1] < total_duration:
-                # teps terms to avoid integration errors over extended periods of time
-                _temp1 = np.array(([-teps, gw[0, 0] - teps], [0, 0]))
-                _temp2 = np.array(([gw[0, -1] + teps, total_duration + teps], [0, 0]))
-                gw = np.hstack((_temp1, gw, _temp2))
-            elif gw[0, 0] > 0:
-                _temp = np.array(([-teps, gw[0, 0] - teps], [0, 0]))
-                gw = np.hstack((_temp, gw))
-            elif gw[0, -1] < total_duration:
-                _temp = np.array(([gw[0, -1] + teps, total_duration + teps], [0, 0]))
-                gw = np.hstack((gw, _temp))
-
-            if abs(gradient_offset[j]) > eps:
-                gw[1,:] += gradient_offset[j]
-
-            gw[1][gw[1] == -0.0] = 0.0
-            # Specify window to be same as domain prevent numpy from remapping to [-1, 1]
-            polyfit = [
-                np.polynomial.Polynomial(
-                    [gw[1,i] - (gw[1, i] - gw[1, i+1]) / (gw[0,i] - gw[0,i+1]) * gw[0,i],
-                     (gw[1, i] - gw[1, i+1]) / (gw[0,i] - gw[0,i+1])],
-                    gw[0, i : (i + 2)],
-                    gw[0, i : (i + 2)]
-                )
-                for i in range(len(gw[0]) - 1)
-                ]
-            
-            polyfit = np.stack(polyfit)
-            gw_pp.append(polyfit)
-
-            ###
-            """
-            Fix coefs for consistency with MATLAB:
-            1. MATLAB returns coefficients in descending order whereas Numpy returns coefficients in ascending order. 
-            2. MATLAB returns local coefficients that will NOT match Numpy's outputs. Refer to the equation under the 
-            "output arguments" section of `mkpp` MATLAB docs to convert and match coefficient outputs.
-            3. Finally, MATLAB seems to not store any -1 < x < 1 coefficients, so we zero them out.
-            """
-            polyfit_MATLAB = []
-            for i in range(len(polyfit)):
-                polyfit_MATLAB_i = copy(polyfit[i])
-                lower = polyfit_MATLAB_i.domain[0]
-                co = polyfit_MATLAB_i.coef
-                co = co[::-1]  # Reverse
-                a = co[0]
-                b = co[1] + (a * lower)
-                if -1 < a < 1:  # to investigate
-                    a = 0
-                if -1 < b < 1:
-                    b = 0
-                # co = [b, a]  # Un-reverse for Numpy
-                co = [a, b]
-                polyfit_MATLAB_i.coef = co
-                polyfit_MATLAB.append(polyfit_MATLAB_i)
-            gw_pp_MATLAB.append(polyfit_MATLAB)
-            ###
-
+        gw_pp = self.get_gradients(trajectory_delay, gradient_offset)
+        ng = len(gw_pp)
+        
         # Calculate slice positions. For now we entirely rely on the excitation -- ignoring complicated interleaved
         # refocused sequences
-        if len(tfp_excitation) > 0:
+        if len(t_excitation) > 0:
             # Position in x, y, z
-            slice_pos = np.zeros((len(gw_data), tfp_excitation.shape[1]))
-            for j in range(len(gw_data)):
+            slice_pos = np.zeros((ng, len(t_excitation)))
+            for j in range(ng):
                 if gw_pp[j] is None:
                     slice_pos[j] = np.nan
                 else:
                     # Check for divisions by zero to avoid numpy warning
-                    divisor = np.array(self.ppval_numpy(gw_pp[j], tfp_excitation[0]))
-                    slice_pos[j, divisor != 0.0] = tfp_excitation[1, divisor != 0.0] / divisor[divisor != 0.0]
+                    divisor = np.array(gw_pp[j](t_excitation))
+                    slice_pos[j, divisor != 0.0] = fp_excitation[0, divisor != 0.0] / divisor[divisor != 0.0]
                     slice_pos[j, divisor == 0.0] = np.nan
                     
             slice_pos[~np.isfinite(slice_pos)] = 0  # Reset undefined to 0
-            t_slice_pos = tfp_excitation[0]
         else:
             slice_pos = []
-            t_slice_pos = []
-
-        # FNINT
-        def fnint(arr_poly):
-            pieces = len(arr_poly)
-            breaks = np.stack([pp.domain for pp in arr_poly])
-            breaks = np.concatenate((breaks[:, 0], [breaks[-1, 1]]))
-            coefs = np.stack([pp.coef for pp in arr_poly])
-            order = len(arr_poly[1].coef)
-            dim = 1
-            coefs = coefs / np.tile(range(order, 0, -1), (dim * pieces, 1))
-            xs = np.diff(breaks[:-1])
-            index = np.arange(pieces - 1)
-            vv = xs * coefs[index, 0]
-            for i in range(1, order):
-                vv = xs * (vv + coefs[index, i])
-            last = np.cumsum(np.concatenate(([0], vv))).reshape((-1, 1))
-
-            coefs = np.hstack((coefs[:, :order], last))
-            arr_poly_integ = []
-            for i in range(pieces):
-                arr_poly_integ.append(
-                    np.polynomial.Polynomial(
-                        coefs[i],
-                        domain=[breaks[i], breaks[i + 1]],
-                        window=[breaks[i], breaks[i + 1]],
-                    )
-                )
-
-            return arr_poly_integ, coefs, breaks
 
         # =========
-
         # Integrate waveforms as PPs to produce gradient moments
         gm_pp = []
         tc = []
         for i in range(ng):
             if gw_pp[i] is None:
+                gm_pp.append(None)
                 continue
-            res_fnint, res_coefs, res_breaks = fnint(gw_pp_MATLAB[i])
-            gm_pp.append(res_fnint)
-            tc.append(res_breaks)
+            
+            gm_pp.append(gw_pp[i].antiderivative())
+            tc.append(gm_pp[i].x)
             # "Sample" ramps for display purposes otherwise piecewise-linear display (plot) fails
-            ii = np.nonzero(np.abs(res_coefs[:, 0]) > eps)[0]
-            if len(ii) > 0:
-                tca = []
-                for j in range(len(ii)):
-                    res = (
-                        np.arange(
-                            math.floor(float(res_breaks[ii[j]] / self.grad_raster_time)),
-                            math.ceil(
-                                (res_breaks[ii[j] + 1] / self.grad_raster_time) + 1
-                            ),
-                        )
-                        * self.grad_raster_time
-                    )
-                    tca.extend(res)
-                tc.append(tca)
-        tc = np.array(list(chain(*tc)))
+            ii = np.flatnonzero(np.abs(gm_pp[i].c[0, :]) > eps)
+            
+            starts = np.int64(np.floor(gm_pp[i].x[ii] / self.grad_raster_time))
+            ends = np.int64(np.ceil(gm_pp[i].x[ii+1] / self.grad_raster_time))
+            
+            # Create all ranges starts[0]:ends[0], starts[1]:ends[1], etc.
+            lengths = ends-starts+1
+            inds = np.ones((lengths).sum())
+            # Calculate output index where each range will start
+            start_inds = np.cumsum(np.concatenate(([0],lengths[:-1])))
+            # Create element-wise differences that will cumsum into
+            # the final indices: [starts[0], 1, 1, starts[1]-starts[0]-lengths[0]+1, 1, etc.]
+            inds[start_inds] = np.concatenate(([starts[0]], np.diff(starts) - lengths[:-1] + 1))
 
-        if len(tfp_excitation) == 0:
-            t_excitation = np.array([])
-        else:
-            t_excitation = tfp_excitation[0]
-
-        if len(tfp_refocusing) == 0:
-            t_refocusing = np.array([])
-        else:
-            t_refocusing = tfp_refocusing[0]
-
+            tc.append(np.cumsum(inds) * self.grad_raster_time)
+        tc = np.concatenate(tc)
+        
+            
         t_acc = 1e-10  # Temporal accuracy
         t_acc_inv = 1 / t_acc
         # tc = self.__flatten_jagged_arr(tc)
@@ -499,10 +278,10 @@ class Sequence:
                     [
                         *tc,
                         0,
-                        *np.array(t_excitation) - 2 * self.rf_raster_time,
-                        *np.array(t_excitation) - self.rf_raster_time,
+                        *np.asarray(t_excitation) - 2 * self.rf_raster_time,
+                        *np.asarray(t_excitation) - self.rf_raster_time,
                         *t_excitation,
-                        *np.array(t_refocusing) - self.rf_raster_time,
+                        *np.asarray(t_refocusing) - self.rf_raster_time,
                         *t_refocusing,
                         *t_adc,
                         total_duration,
@@ -510,13 +289,11 @@ class Sequence:
                 )
             )
         )
-        i_excitation = np.isin(t_ktraj, t_acc * np.round(t_acc_inv * t_excitation))
-        i_excitation = np.nonzero(i_excitation)[0]  # Convert boolean array into indices
-        i_refocusing = np.isin(t_ktraj, t_acc * np.round(t_acc_inv * t_refocusing))
-        i_refocusing = np.nonzero(i_refocusing)[0]  # Convert boolean array into indices
-        i_adc = np.isin(t_ktraj, t_acc * np.round(t_acc_inv * t_adc))
-        i_adc = np.nonzero(i_adc)[0]  # Convert boolean array into indices
 
+        i_excitation = np.searchsorted(t_ktraj, t_acc * np.round(t_acc_inv * np.asarray(t_excitation)))
+        i_refocusing = np.searchsorted(t_ktraj, t_acc * np.round(t_acc_inv * np.asarray(t_refocusing)))
+        i_adc = np.searchsorted(t_ktraj, t_acc * np.round(t_acc_inv * np.asarray(t_adc)))
+        
         i_periods = np.unique([0, *i_excitation, *i_refocusing, len(t_ktraj) - 1])
         if len(i_excitation) > 0:
             ii_next_excitation = 0
@@ -527,16 +304,16 @@ class Sequence:
         else:
             ii_next_refocusing = -1
 
-        k_traj = np.zeros((3, len(t_ktraj)))
+        k_traj = np.zeros((ng, len(t_ktraj)))
         for i in range(ng):
-            if gw_pp_MATLAB[i] is None:
+            if gw_pp[i] is None:
                 continue
 
             it = np.where(np.logical_and(
-                t_ktraj >= t_acc * round(t_acc_inv * res_breaks[0]),
-                t_ktraj <= t_acc * round(t_acc_inv * res_breaks[-1]),
+                t_ktraj >= t_acc * round(t_acc_inv * gm_pp[i].x[0]),
+                t_ktraj <= t_acc * round(t_acc_inv * gm_pp[i].x[-1]),
             ))[0]
-            k_traj[i, it] = self.ppval_MATLAB(gm_pp[i], t_ktraj[it])
+            k_traj[i, it] = gm_pp[i](t_ktraj[it])
             if t_ktraj[it[-1]] < t_ktraj[-1]:
                 k_traj[i, it[-1] + 1 :] = k_traj[i, it[-1]]
 
@@ -555,18 +332,14 @@ class Sequence:
                     # Use nans to mark the excitation points since they interrupt the plots
                     k_traj[:, i_period - 1] = np.NaN
                 # -1 on len(i_excitation) for 0-based indexing
-                ii_next_excitation = np.minimum(
-                    len(i_excitation) - 1, ii_next_excitation + 1
-                )
+                ii_next_excitation = min(len(i_excitation) - 1, ii_next_excitation + 1)
             elif (
                 ii_next_refocusing >= 0 and i_refocusing[ii_next_refocusing] == i_period
             ):
                 # dk = -k_traj[:, i_period]
                 dk = -2 * k_traj[:, i_period] - dk
                 # -1 on len(i_excitation) for 0-based indexing
-                ii_next_refocusing = np.minimum(
-                    len(i_refocusing) - 1, ii_next_refocusing + 1
-                )
+                ii_next_refocusing = min(len(i_refocusing) - 1, ii_next_refocusing + 1)
 
             k_traj[:, i_period:i_period_end] = (
                 k_traj[:, i_period:i_period_end] + dk[:, None]
@@ -576,7 +349,15 @@ class Sequence:
         k_traj_adc = k_traj[:, i_adc]
 
         return k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc
-    
+
+    def calculate_kspacePP(
+            self,
+            trajectory_delay: Union[float, List[float], np.ndarray] = 0,
+            gradient_offset: Union[float, List[float], np.ndarray] = 0
+        ) -> Tuple[np.array, np.array, np.array, np.array, np.array]:
+        warn('Sequence.calculate_kspacePP has been deprecated, use calculate_kspace instead', DeprecationWarning, stacklevel=2)
+        return self.calculate_kspace(trajectory_delay, gradient_offset)
+
     def calculate_pns(
             self, hardware: SimpleNamespace, do_plots: bool = True
             ) -> Tuple[bool, np.array, np.ndarray, np.array]:
@@ -715,39 +496,6 @@ class Sequence:
 
         return duration, num_blocks, event_count
 
-    def __flatten_jagged_arr(self, arr: np.array) -> np.array:
-        # Sanity check: we don't need to do anything if we have a flat array
-        def __flat_check(arr: np.array) -> bool:
-            return all([not isinstance(x, Iterable) for x in arr])
-
-        if __flat_check(arr):
-            return arr
-
-        # Flatten the array simply -- 1 level deep
-        arr_flattened = list(itertools.chain(*arr))
-
-        # Not flat yet?
-        if __flat_check(arr_flattened):
-            return arr_flattened
-
-        # Flatten the array -- 2 levels deep
-        any_ragged = [isinstance(x, Iterable) for x in arr_flattened]
-
-        if np.any(any_ragged):
-            idx_ragged = np.array(np.where(any_ragged)[0])
-            for i in range(len(idx_ragged)):
-                ii = idx_ragged[i]
-
-                # If we are not at the end of the list, we need to update the indices of the remaining elements
-                # Because once we expand and insert this list element, the indices of the remaining elements
-                # will be shifted by len(this element)
-                if i != len(idx_ragged) - 1:
-                    idx_ragged[i + 1 :] += len(arr_flattened[ii])
-
-                arr_flattened = np.insert(arr_flattened, ii, arr_flattened[ii])
-
-        return arr_flattened
-
     def flip_grad_axis(self, axis: str) -> None:
         """
         Invert all gradients along the corresponding axis/channel. The function acts on all gradient objects already
@@ -861,6 +609,93 @@ class Sequence:
 
         extension_str = self.extension_string_idx[num]
         return extension_str
+
+    def get_gradients(self,
+        trajectory_delay: Union[float, List[float], np.ndarray] = 0,
+        gradient_offset: Union[float, List[float], np.ndarray] = 0) -> List[PPoly]:
+        """
+        Get all gradient waveforms of the sequence in a piecewise-polynomial
+        format (scipy PPoly). Gradient values can be accessed easily at one or
+        more timepoints using `gw_pp[channel](t)` (where t is a float, list of
+        floats, or numpy array). Note that PPoly objects return nan for
+        timepoints outside the waveform.
+        
+        Parameters
+        ----------
+        trajectory_delay : float or list, default=0
+            Compensation factor in seconds (s) to align ADC and gradients in the reconstruction.
+        gradient_offset : float or list, default=0
+            Simulates background gradients (specified in Hz/m)
+
+        Returns
+        -------
+        gw_pp : List[PPoly]
+            List of gradient waveforms for each of the gradient channels,
+            expressed as scipy PPoly objects.
+        """
+        if np.any(np.abs(trajectory_delay) > 100e-6):
+            raise Warning(
+                f"Trajectory delay of {trajectory_delay * 1e6} us is suspiciously high"
+            )
+
+        total_duration = sum(self.block_durations)
+        
+        gw_data = self.waveforms()
+        ng = len(gw_data)
+        
+        # Gradient delay handling
+        if isinstance(trajectory_delay, (int, float)):
+            gradient_delays = [trajectory_delay] * ng
+        else:
+            assert(len(trajectory_delay) == ng)  # Need to have same number of gradient channels
+            gradient_delays = [trajectory_delay] * ng
+
+        # Gradient offset handling
+        if isinstance(gradient_offset, (int, float)):
+            gradient_offset = [gradient_offset] * ng
+        else:
+            assert (len(gradient_offset) == ng)  # Need to have same number of gradient channels
+
+        # Convert data to piecewise polynomials
+        gw_pp = []
+        for j in range(ng):
+            wave_cnt = gw_data[j].shape[1]
+            if wave_cnt == 0:
+                if np.abs(gradient_offset[j]) <= eps:
+                    gw_pp.append(None)
+                    continue
+                else:
+                    gw = np.array(([0, total_duration], [0, 0]))
+            else:
+                gw = gw_data[j]
+
+            # Now gw contains the waveform from the current axis
+            if np.abs(gradient_delays[j]) > eps:
+                gw[0] = gw[0] - gradient_delays[j]  # Anisotropic gradient delay support
+            if not np.all(np.isfinite(gw)):
+                raise Warning("Not all elements of the generated waveform are finite.")
+
+            teps = 1e-12
+            if gw[0, 0] > 0 and gw[0, -1] < total_duration:
+                # teps terms to avoid integration errors over extended periods of time
+                _temp1 = np.array(([-teps, gw[0, 0] - teps], [0, 0]))
+                _temp2 = np.array(([gw[0, -1] + teps, total_duration + teps], [0, 0]))
+                gw = np.hstack((_temp1, gw, _temp2))
+            elif gw[0, 0] > 0:
+                _temp = np.array(([-teps, gw[0, 0] - teps], [0, 0]))
+                gw = np.hstack((_temp, gw))
+            elif gw[0, -1] < total_duration:
+                _temp = np.array(([gw[0, -1] + teps, total_duration + teps], [0, 0]))
+                gw = np.hstack((gw, _temp))
+
+            if np.abs(gradient_offset[j]) > eps:
+                gw[1,:] += gradient_offset[j]
+
+            gw[1][gw[1] == -0.0] = 0.0
+
+            gw_pp.append(PPoly(np.stack((np.diff(gw[1]) / np.diff(gw[0]),
+                                         gw[1][:-1])), gw[0], extrapolate=False))
+        return gw_pp
 
     def mod_grad_axis(self, axis: str, modifier: int) -> None:
         """
@@ -1137,68 +972,6 @@ class Sequence:
         if plot_now:
             plt.show()
 
-    def ppval_numpy(self, arr_np_poly: np.ndarray, xq: np.ndarray):
-        """
-        Perform piece-wise polynomial evaluation on Numpy's polyfit objects.
-
-        Parameters
-        ==========
-        arr_np_poly : Iterable[np.poly1d]
-        xq : np.array
-
-        Returns
-        =======
-        """
-        result = []
-        result2 = []
-        breaks = np.array([p.domain for p in arr_np_poly])
-        breaks = np.array([*breaks[::2].flatten(), breaks[-1, -1]])
-        last_match = 0
-        for x in xq:
-            # Evaluate polynomial only when we find x's corresponding pp window
-            for i in range(last_match, len(arr_np_poly)):
-                corresponding_pp = x > arr_np_poly[i].domain
-                if corresponding_pp.tolist() == [True, False]:
-                    value = np.polynomial.polynomial.polyval(x, arr_np_poly[i].coef)
-                    result.append(value)
-                    last_match = i
-                    break
-
-            corresponding_pp2 = np.nonzero((x < breaks))[0][0]
-            value2 = np.polynomial.polynomial.polyval(
-                x, arr_np_poly[corresponding_pp2].coef
-            )
-            result2.append(value2)
-
-        return result
-
-    def ppval_MATLAB(self, arr_MATLAB_poly: np.ndarray, xq: np.ndarray) -> np.array:
-        """
-        Perform piece-wise polynomial evaluation on MATLAB's polyfit objects.
-
-        Returns
-        =======
-        """
-
-        def __ppval(c, x, b, i, n):
-            return c[n] * (x - b) ** i + __ppval(c, x, b, i + 1, n - 1) if n >= 0 else 0
-
-        coefs = np.array([p.coef for p in arr_MATLAB_poly])
-        breaks = np.array([p.domain for p in arr_MATLAB_poly])
-        breaks = np.array([*breaks[::2].flatten(), breaks[-1, -1]])
-        result = []
-
-        for x in xq:
-            corresponding_pp = np.nonzero((x < breaks))[0][0]
-            c = coefs[corresponding_pp - 1]
-            b = breaks[corresponding_pp - 1]
-            # c = coefs[2]
-            # res = c[0] * (x - breaks[2]) ** 2 + c[1] * (x - breaks[2]) + c[2]
-            res = __ppval(c, x, b, i=0, n=len(c) - 1)
-            result.append(res)
-
-        return np.array(result)
-
     def read(self, file_path: str, detect_rf_use: bool = False) -> None:
         """
         Read `.seq` file from `file_path`.
@@ -1287,6 +1060,76 @@ class Sequence:
 
         return rf
 
+    def rf_times(
+        self, time_range: List[float] = None
+    ) -> Tuple[List[float], np.ndarray, List[float], np.ndarray, np.ndarray]:
+        """
+        Return time points of excitations and refocusings.
+
+        Returns
+        -------
+        t_excitation : List[float]
+            Contains time moments of the excitation RF pulses
+        fp_excitation : np.ndarray
+            Contains frequency and phase offsets of the excitation RF pulses
+        t_refocusing : List[float]
+            Contains time moments of the refocusing RF pulses
+        fp_refocusing : np.ndarray
+            Contains frequency and phase offsets of the excitation RF pulses
+        """
+
+        num_blocks = len(self.block_events)
+
+        # Collect RF timing data
+        t_excitation = []
+        fp_excitation = []
+        t_refocusing = []
+        fp_refocusing = []
+
+        curr_dur = 0
+
+        if time_range == None:
+            begin_block = 0
+            end_block = num_blocks
+        else:
+            if len(time_range) != 2:
+                raise ValueError('Time range must be list of two elements')
+            
+            t = np.cumsum(self.block_durations)
+            begin_block = np.searchsorted(t, time_range[0])
+            end_block = np.searchsorted(t - self.block_durations, time_range[1], side='right')
+
+        for block_counter in range(begin_block, end_block):
+            block = self.get_block(block_counter + 1)
+            
+            if block.rf is not None:  # RF
+                rf = block.rf
+                t = rf.delay + calc_rf_center(rf)[0]
+                if not hasattr(rf, "use") or block.rf.use in [
+                    "excitation",
+                    "undefined",
+                ]:
+                    t_excitation.append(curr_dur + t)
+                    fp_excitation.append([block.rf.freq_offset, block.rf.phase_offset])
+                elif block.rf.use == "refocusing":
+                    t_refocusing.append(curr_dur + t)
+                    fp_refocusing.append([block.rf.freq_offset, block.rf.phase_offset])
+
+            curr_dur += self.block_durations[block_counter]
+
+
+        if len(t_excitation) != 0:
+            fp_excitation = np.array(fp_excitation).T
+        else:
+            fp_excitation = np.empty((2,0))
+            
+        if len(t_refocusing) != 0:
+            fp_refocusing = np.array(fp_refocusing).T
+        else:
+            fp_refocusing = np.empty((2,0))
+        
+        return t_excitation, fp_excitation, t_refocusing, fp_refocusing
+
     def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
         """
         Replace block at index with new block provided as block structure, add sequence block, or create a new block
@@ -1362,14 +1205,14 @@ class Sequence:
         """
         return ext_test_report(self)
 
-    def waveforms_and_times(
-        self, append_RF: bool = False
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+
+    def waveforms(
+        self, append_RF: bool = False, time_range: List[float] = None
+    ) -> Tuple[np.ndarray]:
         """
         Decompress the entire gradient waveform. Returns gradient waveforms as a tuple of `np.ndarray` of
         `gradient_axes` (typically 3) dimensions. Each `np.ndarray` contains timepoints and the corresponding
-        gradient amplitude values. Additional return values are time points of excitations, refocusings and ADC
-        sampling points.
+        gradient amplitude values.
 
         Parameters
         ----------
@@ -1379,14 +1222,6 @@ class Sequence:
         Returns
         -------
         wave_data : np.ndarray
-        tfp_excitation : np.ndarray
-            Contains time moments, frequency and phase offsets of the excitation RF pulses (similar for `
-            tfp_refocusing`).
-        tfp_refocusing : np.ndarray
-        t_adc: np.ndarray
-            Contains times of all ADC sample points.
-        fp_adc : np.ndarray
-            Contains frequency and phase offsets of each ADC object (not samples).
         """
         grad_channels = ["gx", "gy", "gz"]
 
@@ -1399,18 +1234,24 @@ class Sequence:
             shape_channels = len(grad_channels)
 
         shape_pieces = [[] for _ in range(shape_channels)]
-        # Also collect RF and ADC timing data
-        # t_excitation, t_refocusing, t_adc
-        tfp_excitation = []
-        tfp_refocusing = []
-        t_adc = []
-        fp_adc = []
 
         curr_dur = 0
         out_len = np.zeros(shape_channels)  # Last 'channel' is RF
 
-        for block_counter in range(num_blocks):
+        if time_range == None:
+            begin_block = 0
+            end_block = num_blocks
+        else:
+            if len(time_range) != 2:
+                raise ValueError('Time range must be list or tuple of two elements')
+            
+            t = np.cumsum(self.block_durations)
+            begin_block = np.searchsorted(t, time_range[0])
+            end_block = np.searchsorted(t - self.block_durations, time_range[1], side='right')
+
+        for block_counter in range(begin_block, end_block):
             block = self.get_block(block_counter + 1)
+            
             for j in range(len(grad_channels)):
                 grad = getattr(block, grad_channels[j])
                 if grad is not None:  # Gradients
@@ -1476,20 +1317,7 @@ class Sequence:
 
             if block.rf is not None:  # RF
                 rf = block.rf
-                t = rf.delay + calc_rf_center(rf)[0]
-                if not hasattr(rf, "use") or block.rf.use in [
-                    "excitation",
-                    "undefined",
-                ]:
-                    tfp_excitation.append(
-                        [curr_dur + t, block.rf.freq_offset, block.rf.phase_offset]
-                    )
-                elif block.rf.use == "refocusing":
-                    tfp_refocusing.append(
-                        [curr_dur + t, block.rf.freq_offset, block.rf.phase_offset]
-                    )
                 if append_RF:
-
                     rf_piece = np.array(
                         [
                             curr_dur + rf.delay + rf.t,
@@ -1513,14 +1341,6 @@ class Sequence:
                         out_len[-1] += post.shape[1]
 
                     shape_pieces[-1].append(rf_piece)
-
-            if block.adc is not None:  # ADC
-                t_adc.extend(
-                    (np.arange(block.adc.num_samples) + 0.5) * block.adc.dwell
-                    + block.adc.delay
-                    + curr_dur
-                )
-                fp_adc.append([block.adc.freq_offset, block.adc.phase_offset])
 
             curr_dur += self.block_durations[block_counter]
 
@@ -1547,11 +1367,44 @@ class Sequence:
                     "Time vector elements are not monotonically increasing."
                 )
 
-        tfp_excitation = np.array(tfp_excitation).transpose()
-        tfp_refocusing = np.array(tfp_refocusing).transpose()
-        t_adc = np.array(t_adc)
-        fp_adc = np.array(fp_adc)
+        return wave_data
 
+
+    def waveforms_and_times(
+        self, append_RF: bool = False, time_range: List[float] = None
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Decompress the entire gradient waveform. Returns gradient waveforms as a tuple of `np.ndarray` of
+        `gradient_axes` (typically 3) dimensions. Each `np.ndarray` contains timepoints and the corresponding
+        gradient amplitude values. Additional return values are time points of excitations, refocusings and ADC
+        sampling points.
+
+        Parameters
+        ----------
+        append_RF : bool, default=False
+            Boolean flag to indicate if RF wave shapes are to be appended after the gradients.
+
+        Returns
+        -------
+        wave_data : np.ndarray
+        tfp_excitation : np.ndarray
+            Contains time moments, frequency and phase offsets of the excitation RF pulses (similar for `
+            tfp_refocusing`).
+        tfp_refocusing : np.ndarray
+        t_adc: np.ndarray
+            Contains times of all ADC sample points.
+        fp_adc : np.ndarray
+            Contains frequency and phase offsets of each ADC object (not samples).
+        """
+        
+        wave_data = self.waveforms(append_RF=append_RF, time_range=time_range)
+        t_excitation, fp_excitation, t_refocusing, fp_refocusing = self.rf_times(time_range=time_range)
+        t_adc, fp_adc = self.adc_times(time_range=time_range)
+        
+        # Join times, frequency and phases of RF pulses for compatibility with previous implementation
+        tfp_excitation = np.concatenate((np.array(t_excitation)[None], fp_excitation), axis=0)
+        tfp_refocusing = np.concatenate((np.array(t_refocusing)[None], fp_refocusing), axis=0)
+        
         return wave_data, tfp_excitation, tfp_refocusing, t_adc, fp_adc
 
     def waveforms_export(self, time_range=(0, np.inf)) -> dict:
@@ -1604,14 +1457,14 @@ class Sequence:
         gy_all = np.array([])
         gz_all = np.array([])
 
-        for block_counter in range(len(self.dict_block_events)):  # For each block
+        for block_counter in range(len(self.block_events)):  # For each block
             block = self.get_block(block_counter + 1)  # Retrieve it
             is_valid = (
                 time_range[0] <= t0 <= time_range[1]
             )  # Check if "current time" is within requested range.
             if is_valid:
                 # Case 1: ADC
-                if hasattr(block, "adc"):
+                if block.adc != None:
                     adc = block.adc  # Get adc info
                     # From Pulseq: According to the information from Klaus Scheffler and indirectly from Siemens this
                     # is the present convention - the samples are shifted by 0.5 dwell
@@ -1623,7 +1476,7 @@ class Sequence:
                     adc_t_all = np.concatenate((adc_t_all, adc_t))
                     adc_signal_all = np.concatenate((adc_signal_all, adc_signal))
 
-                if hasattr(block, "rf"):
+                if block.rf != None:
                     rf = block.rf
                     tc, ic = calc_rf_center(rf)
                     t = rf.t + rf.delay
@@ -1652,9 +1505,8 @@ class Sequence:
                 for x in range(
                     len(grad_channels)
                 ):  # Check each gradient channel: x, y, and z
-                    if hasattr(
-                        block, grad_channels[x]
-                    ):  # If this channel is on in current block
+                    if getattr(block, grad_channels[x]) != None:
+                        # If this channel is on in current block
                         grad = getattr(block, grad_channels[x])
                         if grad.type == "grad":  # Arbitrary gradient option
                             # In place unpacking of grad.t with the starred expression

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -65,7 +65,7 @@ def write(self, file_name: str, create_signature) -> None:
         id_format_str = id_format_width + " {:3d} {:3d} {:3d} {:3d} {:3d} {:2d} {:2d}\n"
         for block_counter in range(len(self.block_events)):
             block_duration = (
-                self.block_durations[block_counter] / self.block_duration_raster
+                self.block_durations[block_counter + 1] / self.block_duration_raster
             )
             block_duration_rounded = round(block_duration)
 

--- a/pypulseq/seq_examples/scripts/write_gre.py
+++ b/pypulseq/seq_examples/scripts/write_gre.py
@@ -134,7 +134,7 @@ def main(plot: bool, write_seq: bool, seq_filename: str = "gre_pypulseq.seq"):
     if plot:
         seq.plot()
 
-    seq.calculate_kspacePP()
+    seq.calculate_kspace()
 
     # Very optional slow step, but useful for testing during development e.g. for the real TE, TR or for staying within
     # slew-rate limits


### PR DESCRIPTION
This implements `calculate_kspacePP` using scipy's `PPoly` object, which behaves very similar to the Matlab implementation. This is obviously much cleaner, and also much faster. A helper function `get_gradients` is also available to immediately get access to the waveforms in `PPoly` format.
I renamed the function to `calculate_kspace`, because this function was no longer functional, and not intended to be used anymore anyway. I added a deprecation warning for `calculate_kspacePP`, but this function could also just be removed altogether. This also resolves #107.

Furthermore, I split `waveforms_and_times` into three functions: `waveforms`, `adc_times`, and `rf_times`. This allows efficient access to for example only the excitation times (e.g. when only calculating TE/TR). `waveforms_and_times` remains compatible with the previous implementation, but `rf_times` returns excitation/refocusing times and frequency/phase in separate arrays (instead of the non-intuitive `tfp_` variables).

Further small changes:
- Improved performance of calculating of `tc` in `calculate_kspace` (especially in sequences with ramp-sampling)
- Changed `block_durations` in Sequence to be a dictionary, to avoid potential issues when using non-incremental block IDs (previous code assumed this was the case)
- Fixed `waveforms_export` (though this function seems a bit superfluous with the other ways to access this information)