### PR TITLE
Enh: Enable GitHub CI

### DIFF
--- a/.github/requirements.yml
+++ b/.github/requirements.yml
@@ -1,0 +1,3 @@
+dependencies:
+ - flake8
+ - pytest

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -1,0 +1,42 @@
+name: Run code tests on push and pull requests
+on:
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Code tests (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: ["ubuntu-latest"]
+            python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          lfs: true
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+          environment-file: .github/requirements.yml
+          auto-activate-base: false
+          channels: conda-forge
+      - shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: Lint
+        shell: bash -l {0}
+        run: |
+            python -m flake8 pypulseq
+      - name: Run pytest
+        shell: bash -l {0}
+        run: |
+            pip install .
+            pytest pypulseq/tests

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,10 +31,10 @@ jobs:
         run: |
           conda info
           conda list
-      - name: Lint
-        shell: bash -l {0}
-        run: |
-            python -m flake8 pypulseq
+      # - name: Lint
+      #   shell: bash -l {0}
+      #   run: |
+      #       python -m flake8 pypulseq
       - name: Run pytest
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Hi,

This PR enables running the included tests using the pytest module, utilising the Github CI / Actions facility. This was briefly discussed in Issue #119 . 

I've lifted this from my own python package https://github.com/wtclarke/nifti_mrs_tools/blob/master/.github/workflows/push_pr.yml. There's also an example in there for implementing a publishing pathway with the Github releases framework.

Note that the tests currently don't complete sucessfulyl as th `pypulseq/tests/matlab_seqs/` directory is missing from the repository.
