### PR TITLE
BF: make_trapezoid with amplitude + duration as inputs.

### DIFF
--- a/pypulseq/SAR/SAR_calc.py
+++ b/pypulseq/SAR/SAR_calc.py
@@ -5,7 +5,6 @@ from typing import Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.matlib
 import scipy.io as sio
 from scipy import interpolate
 

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -152,7 +152,7 @@ def make_trapezoid(
                     f"Requested area is too large for this gradient. Minimum required duration is "
                     f"{round(min_duration * 1e6)} uss"
                 )
-                
+
                 dC = 1 / abs(2 * max_slew) + 1 / abs(2 * max_slew)
                 amplitude2 = (
                     duration - math.sqrt(duration**2 - 4 * abs(area) * dC)
@@ -168,6 +168,8 @@ def make_trapezoid(
                     f"Requested area is too large for this gradient. Probably amplitude is violated "
                     f"{round(abs(amplitude) / max_grad * 100)}"
                 )
+        else:
+            amplitude2 = amplitude
 
         if rise_time == 0:
             rise_time = (
@@ -185,7 +187,7 @@ def make_trapezoid(
             # Adjust amplitude (after rounding) to match area
             amplitude2 = area / (rise_time / 2 + fall_time / 2 + flat_time)
     else:
-        if area == None:
+        if area is None:
             raise ValueError("Must supply area or duration.")
         else:
             # Find the shortest possible duration.           

--- a/pypulseq/tests/test_make_trapezoid.py
+++ b/pypulseq/tests/test_make_trapezoid.py
@@ -68,14 +68,14 @@ def test_no_area_no_duration_error():
             match=errstr):
         make_trapezoid(channel='x',  amplitude=1)
 
-# Currently seemingly unreachable.
-# def test_amplitude_too_large_error():
-#     errstr = "Amplitude violation."
 
-    # with pytest.raises(
-    #         ValueError,
-    #         match=errstr):
-    #     make_trapezoid(channel='x',  amplitude=1E10, duration=1)
+def test_amplitude_too_large_error():
+    errstr = "Amplitude violation."
+
+    with pytest.raises(
+            ValueError,
+            match=errstr):
+        make_trapezoid(channel='x',  amplitude=1E10, duration=1)
 
 
 def test_generation_methods():
@@ -92,7 +92,6 @@ def test_generation_methods():
         make_trapezoid(channel='x', flat_area=0.5, duration=1, area=1),
         SimpleNamespace)
 
-    # Currently doesn't work
-    # assert isinstance(
-    #     make_trapezoid(channel='x',  amplitude=1, duration=1),
-    #     SimpleNamespace)
+    assert isinstance(
+        make_trapezoid(channel='x',  amplitude=1, duration=1),
+        SimpleNamespace)

--- a/pypulseq/tests/test_make_trapezoid.py
+++ b/pypulseq/tests/test_make_trapezoid.py
@@ -33,8 +33,8 @@ def test_area_flatarea_amplitude_error():
 
 
 def test_flat_time_error():
-    errstr = "When `flat_time` is provided, either `flat_area` or `amplitude` must be provided as well; you may "\
-             "consider providing `duration`, `area` and optionally ramp times instead."
+    errstr = "When `flat_time` is provided, either `flat_area`, "\
+             "or `amplitude`, or `rise_time` and `area` must be provided as well."
 
     with pytest.raises(
             ValueError,
@@ -70,28 +70,40 @@ def test_no_area_no_duration_error():
 
 
 def test_amplitude_too_large_error():
-    errstr = "Amplitude violation."
+    errstr = r"Refined amplitude \(\d+ Hz/m\) is larger than max \(\d+ Hz/m\)."
 
     with pytest.raises(
-            ValueError,
+            AssertionError,
             match=errstr):
         make_trapezoid(channel='x',  amplitude=1E10, duration=1)
 
 
 def test_generation_methods():
+    """Test minimum input cases
+    Cover:
+        - area
+        - amplitude and duration
+        - flat_time and flat_area
+        - flat_time and amplitude
+        - flat_time, area and rise_time
+    """
 
     assert isinstance(
         make_trapezoid(channel='x',  area=1),
         SimpleNamespace)
 
     assert isinstance(
-        make_trapezoid(channel='x', flat_area=1, flat_time=1),
-        SimpleNamespace)
-
-    assert isinstance(
-        make_trapezoid(channel='x', flat_area=0.5, duration=1, area=1),
-        SimpleNamespace)
-
-    assert isinstance(
         make_trapezoid(channel='x',  amplitude=1, duration=1),
+        SimpleNamespace)
+
+    assert isinstance(
+        make_trapezoid(channel='x', flat_time=1, flat_area=1),
+        SimpleNamespace)
+
+    assert isinstance(
+        make_trapezoid(channel='x', flat_time=1, amplitude=1),
+        SimpleNamespace)
+
+    assert isinstance(
+        make_trapezoid(channel='x', flat_time=0.5, area=1, rise_time=0.1),
         SimpleNamespace)

--- a/pypulseq/tests/test_make_trapezoid.py
+++ b/pypulseq/tests/test_make_trapezoid.py
@@ -1,0 +1,98 @@
+"""Tests for the make_trapezoid module
+
+Will Clarke, University of Oxford, 2023
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pypulseq import make_trapezoid
+
+
+def test_channel_error():
+
+    with pytest.raises(
+            ValueError,
+            match=r"Invalid channel. Must be one of `x`, `y` or `z`. Passed:"):
+        make_trapezoid(channel='p')
+
+
+def test_falltime_risetime_error():
+    with pytest.raises(
+            ValueError,
+            match=r"Invalid arguments. Must always supply `rise_time` if `fall_time` is specified explicitly."):
+        make_trapezoid(channel='x', fall_time=10)
+
+
+def test_area_flatarea_amplitude_error():
+    with pytest.raises(
+            ValueError,
+            match=r"Must supply either 'area', 'flat_area' or 'amplitude'."):
+        make_trapezoid(channel='x')
+
+
+def test_flat_time_error():
+    errstr = "When `flat_time` is provided, either `flat_area` or `amplitude` must be provided as well; you may "\
+             "consider providing `duration`, `area` and optionally ramp times instead."
+
+    with pytest.raises(
+            ValueError,
+            match=errstr):
+        make_trapezoid(channel='x', flat_time=10, area=10)
+
+
+def test_area_too_large_error():
+    errstr = "Requested area is too large for this gradient. Minimum required duration is"
+
+    with pytest.raises(
+            AssertionError,
+            match=errstr):
+        make_trapezoid(channel='x', area=1E6, duration=1E-6)
+
+
+def test_area_too_large_error_rise_time():
+    errstr = "Requested area is too large for this gradient. Probably amplitude is violated"
+
+    with pytest.raises(
+            AssertionError,
+            match=errstr):
+        make_trapezoid(channel='x',  area=1E6, duration=1E-6, rise_time=1E-7)
+
+
+def test_no_area_no_duration_error():
+    errstr = "Must supply area or duration."
+
+    with pytest.raises(
+            ValueError,
+            match=errstr):
+        make_trapezoid(channel='x',  amplitude=1)
+
+# Currently seemingly unreachable.
+# def test_amplitude_too_large_error():
+#     errstr = "Amplitude violation."
+
+    # with pytest.raises(
+    #         ValueError,
+    #         match=errstr):
+    #     make_trapezoid(channel='x',  amplitude=1E10, duration=1)
+
+
+def test_generation_methods():
+
+    assert isinstance(
+        make_trapezoid(channel='x',  area=1),
+        SimpleNamespace)
+
+    assert isinstance(
+        make_trapezoid(channel='x', flat_area=1, flat_time=1),
+        SimpleNamespace)
+
+    assert isinstance(
+        make_trapezoid(channel='x', flat_area=0.5, duration=1, area=1),
+        SimpleNamespace)
+
+    # Currently doesn't work
+    # assert isinstance(
+    #     make_trapezoid(channel='x',  amplitude=1, duration=1),
+    #     SimpleNamespace)


### PR DESCRIPTION
This should fix the issue described in #145. It also adds partial tests for the `make_trapezoid` function. Finally it removes a unused inport that was throwing warnings with tests in the `pypulseq/SAR/SAR_calc.py` module.