### PR TITLE
Bump sigpy version to 0.1.26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "matplotlib>=3.5.2",
         "numpy>=1.19.5",
         "scipy>=1.8.1",
-        "sigpy@git+https://github.com/mikgroup/sigpy",  # change before release to PyPI
+        "sigpy>=0.1.26",
     ],
     license="License :: OSI Approved :: GNU Affero General Public License v3",
     long_description=_get_long_description(),


### PR DESCRIPTION
Hi folks, SigPy looks to have merged the NumPy fixes mentioned in #119  about 3 weeks ago - this PR just bumps the version in the setup.py file. I wasn't sure about patch version updates since versioning tracks Pulseq mainline, so the only change currenlty here is in the install_requires. 