### PR TITLE
Various bug fixes, features, and cleanups

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -194,6 +194,9 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                 )
 
             if block_index > 1:
+                # TODO: block_index - 1 assumes linear ordering of blocks.
+                #       However, searching for the previous block index in block_events is a big performance hit
+                #       For newly inserted blocks (block_index not in self.block_events), we can just use the last block as previous
                 prev_id = self.block_events[block_index - 1][grad_to_check.idx]
                 if prev_id != 0:
                     prev_lib = self.grad_library.get(prev_id)

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -261,13 +261,13 @@ def get_block(self, block_index: int) -> SimpleNamespace:
         block.delay = delay
 
     if event_ind[1] > 0:  # RF
-        if len(self.rf_library.type) >= event_ind[1]:
+        if event_ind[1] in self.rf_library.type:
             block.rf = self.rf_from_lib_data(
                 self.rf_library.data[event_ind[1]], self.rf_library.type[event_ind[1]]
             )
         else:
             block.rf = self.rf_from_lib_data(
-                self.rf_library.data[event_ind[1]]
+                self.rf_library.data[event_ind[1]] , 'u'
             )  # Undefined type/use
 
     # Gradients

--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -88,17 +88,6 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
                 channel_num = ["x", "y", "z"].index(event.channel)
                 idx = 2 + channel_num
 
-                check_g[channel_num] = SimpleNamespace()
-                check_g[channel_num].idx = idx
-                check_g[channel_num].start = (0, 0)
-                check_g[channel_num].stop = (
-                        event.delay
-                        + event.rise_time
-                        + event.fall_time
-                        + event.flat_time,
-                        0,
-                    )
-
                 if hasattr(event, "id"):
                     trap_id = event.id
                 else:

--- a/pypulseq/Sequence/ext_test_report.py
+++ b/pypulseq/Sequence/ext_test_report.py
@@ -15,7 +15,7 @@ def ext_test_report(self) -> str:
     """
     # Find RF pulses and list flip angles
     flip_angles_deg = []
-    for k in self.rf_library.keys:
+    for k in self.rf_library.data:
         lib_data = self.rf_library.data[k]
         if len(self.rf_library.type) >= k:
             rf = self.rf_from_lib_data(lib_data, self.rf_library.type[k])

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -289,6 +289,10 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
 
                 amplitude_ID = event_idx[j + 2]
                 if amplitude_ID in event_idx[2:(j+2)]: # We did this update for the previous channels, don't do it again.
+                    if self.use_block_cache:
+                        # Update block cache in-place using the first/last values that should now be in the grad_library
+                        grad.first = self.grad_library.data[amplitude_ID][4]
+                        grad.last = self.grad_library.data[amplitude_ID][5]
                     continue
 
                 grad.first = grad_prev_last[j]
@@ -324,11 +328,6 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
                         grad.last,
                 )
                 self.grad_library.update_data(amplitude_ID, None, new_data, "g")
-
-                # Remove the block from the cache and re-add it
-                if self.use_block_cache:
-                    del self.block_cache[block_counter] # TODO: I feel like the update_data function should be responsible for this.
-                    block = self.get_block(block_counter)
 
             else:
                 grad_prev_last[j] = 0

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -215,7 +215,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
     # Fix blocks, gradients and RF objects imported from older versions
     if version_combined < 1004000:
         # Scan through RF objects
-        for i in self.rf_library.data.keys():
+        for i in self.rf_library.data:
             self.rf_library.data[i] = [
                 *self.rf_library.data[i][:3],
                 0,
@@ -224,7 +224,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
             self.rf_library.lengths[i] += 1
 
         # Scan through the gradient objects and update 't'-s (trapezoids) und 'g'-s (free-shape gradients)
-        for i in self.grad_library.data.keys():
+        for i in self.grad_library.data:
             if self.grad_library.type[i] == "t":
                 if self.grad_library.data[i][1] == 0:
                     if (
@@ -342,7 +342,7 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
     if detect_rf_use:
         # Find the RF pulses, list flip angles, and work around the current (rev 1.2.0) Pulseq file format limitation
         # that the RF pulse use is not stored in the file
-        for k in self.rf_library.keys.keys():
+        for k in self.rf_library.data:
             lib_data = self.rf_library.data[k]
             rf = self.rf_from_lib_data(lib_data)
             flip_deg = np.abs(np.sum(rf.signal[:-1] * (rf.t[1:] - rf.t[:-1]))) * 360

--- a/pypulseq/Sequence/read_seq.py
+++ b/pypulseq/Sequence/read_seq.py
@@ -253,24 +253,24 @@ def read(self, path: str, detect_rf_use: bool = False) -> None:
         # For versions prior to 1.4.0 block_durations have not been initialized
         self.block_durations = dict()
         # Scan through blocks and calculate durations
-        for block_counter in range(len(self.block_events)):
-            block = self.get_block(block_counter + 1)
-            if delay_ind_temp[block_counter + 1] > 0:
+        for block_counter in self.block_events:
+            block = self.get_block(block_counter)
+            if delay_ind_temp[block_counter] > 0:
                 block.delay = SimpleNamespace()
                 block.delay.type = "delay"
                 block.delay.delay = temp_delay_library.data[
-                    delay_ind_temp[block_counter + 1]
+                    delay_ind_temp[block_counter]
                 ]
-            self.block_durations[block_counter + 1] = calc_duration(block)
+            self.block_durations[block_counter] = calc_duration(block)
 
     grad_channels = ["gx", "gy", "gz"]
     grad_prev_last = np.zeros(len(grad_channels))
-    for block_counter in range(len(self.block_events)):
-        block = self.get_block(block_counter + 1)
+    for block_counter in self.block_events:
+        block = self.get_block(block_counter)
         block_duration = block.block_duration
         # We also need to keep track of the event IDs because some PyPulseq files written by external software may contain
         # repeated entries so searching by content will fail
-        event_idx = self.block_events[block_counter + 1]
+        event_idx = self.block_events[block_counter]
         # Update the objects by filling in the fields not contained in the PyPulseq file
         for j in range(len(grad_channels)):
             grad = getattr(block, grad_channels[j])

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1,10 +1,8 @@
 import itertools
 import math
 from collections import OrderedDict
-from copy import copy
-from itertools import chain
 from types import SimpleNamespace
-from typing import Tuple, List, Iterable
+from typing import Tuple, List
 from typing import Union
 from warnings import warn
 
@@ -117,7 +115,7 @@ class Sequence:
 
     def adc_times(
         self, time_range: List[float] = None
-    ) -> Tuple[List[float], np.ndarray, List[float], np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Return time points of ADC sampling points.
 
@@ -165,9 +163,13 @@ class Sequence:
 
             curr_dur += self.block_durations[block_counter]
         
-
-        t_adc = np.concatenate(t_adc)
-        fp_adc = np.array(fp_adc)
+        if t_adc == []:
+            # If there are no ADCs, make sure the output is the right shape
+            t_adc = np.zeros(0)
+            fp_adc = np.zeros((0,2))
+        else:
+            t_adc = np.concatenate(t_adc)
+            fp_adc = np.array(fp_adc)
 
         return t_adc, fp_adc
 
@@ -993,6 +995,9 @@ class Sequence:
         file_path : str
             Path to `.seq` file to be read.
         """
+        if self.use_block_cache:
+            self.block_cache.clear()
+
         read(self, path=file_path, detect_rf_use=detect_rf_use)
 
         # Initialize next free block ID

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -44,7 +44,10 @@ class Sequence:
     version_minor = minor
     version_revision = revision
 
-    def __init__(self, system=Opts(), use_block_cache=True):
+    def __init__(self, system=None, use_block_cache=True):
+        if system == None:
+            system = Opts()
+            
         # =========
         # EVENT LIBRARIES
         # =========

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -372,7 +372,10 @@ class Sequence:
         return self.calculate_kspace(trajectory_delay, gradient_offset)
 
     def calculate_pns(
-            self, hardware: SimpleNamespace, do_plots: bool = True
+            self,
+            hardware: SimpleNamespace,
+            time_range: List[float] = None,
+            do_plots: bool = True
             ) -> Tuple[bool, np.array, np.ndarray, np.array]:
         """
         Calculate PNS using safe model implementation by Szczepankiewicz and Witzel
@@ -403,7 +406,7 @@ class Sequence:
         t_pns : np.array [N]
             Time axis for the pns_norm and pns_components arrays
         """
-        return calc_pns(self, hardware, do_plots=do_plots)
+        return calc_pns(self, hardware, time_range=time_range, do_plots=do_plots)
 
     def check_timing(self) -> Tuple[bool, List[str]]:
         """
@@ -624,7 +627,8 @@ class Sequence:
 
     def get_gradients(self,
         trajectory_delay: Union[float, List[float], np.ndarray] = 0,
-        gradient_offset: Union[float, List[float], np.ndarray] = 0) -> List[PPoly]:
+        gradient_offset: Union[float, List[float], np.ndarray] = 0,
+        time_range: List[float] = None) -> List[PPoly]:
         """
         Get all gradient waveforms of the sequence in a piecewise-polynomial
         format (scipy PPoly). Gradient values can be accessed easily at one or
@@ -652,7 +656,7 @@ class Sequence:
 
         total_duration = sum(self.block_durations.values())
         
-        gw_data = self.waveforms()
+        gw_data = self.waveforms(time_range=time_range)
         ng = len(gw_data)
         
         # Gradient delay handling

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -1,11 +1,13 @@
 import hashlib
+from pathlib import Path
+from typing import Union
 
 import numpy as np
 
 from pypulseq.supported_labels_rf_use import get_supported_labels
 
 
-def write(self, file_name: str, create_signature) -> None:
+def write(self, file_name: Union[str, Path], create_signature) -> None:
     """
     Write the sequence data to the given filename using the open file format for MR sequences.
 
@@ -13,7 +15,7 @@ def write(self, file_name: str, create_signature) -> None:
 
     Parameters
     ----------
-    file_name : str
+    file_name : str or Path
         File name of `.seq` file to be written to disk.
     create_signature : bool
 
@@ -24,7 +26,11 @@ def write(self, file_name: str, create_signature) -> None:
     """
     # `>.0f` for decimals.
     # `>g` to truncate insignificant zeros.
-    file_name += ".seq" if file_name[-4:] != ".seq" not in file_name else ""
+    file_name = Path(file_name)
+    if file_name.suffix != '.seq':
+        # Append .seq suffix
+        file_name = file_name.with_suffix(file_name.suffix + '.seq')
+        
     with open(file_name, "w") as output_file:
         output_file.write("# Pulseq sequence file\n")
         output_file.write("# Created by PyPulseq\n\n")

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -81,7 +81,7 @@ def write(self, file_name: str, create_signature) -> None:
             output_file.write(s)
         output_file.write("\n")
 
-        if len(self.rf_library.keys) != 0:
+        if len(self.rf_library.data) != 0:
             output_file.write("# Format of RF events:\n")
             output_file.write(
                 "# id amplitude mag_id phase_id time_shape_id delay freq phase\n"
@@ -90,9 +90,8 @@ def write(self, file_name: str, create_signature) -> None:
                 "# ..        Hz   ....     ....          ....    us   Hz   rad\n"
             )
             output_file.write("[RF]\n")
-            rf_lib_keys = self.rf_library.keys
             id_format_str = "{:.0f} {:12g} {:.0f} {:.0f} {:.0f} {:g} {:g} {:g}\n"  # Refer lines 20-21
-            for k in rf_lib_keys.keys():
+            for k in self.rf_library.data:
                 lib_data1 = self.rf_library.data[k][0:4]
                 lib_data2 = self.rf_library.data[k][5:7]
                 delay = (
@@ -117,7 +116,7 @@ def write(self, file_name: str, create_signature) -> None:
             output_file.write("# ..      Hz/m       ..         ..          us\n")
             output_file.write("[GRADIENTS]\n")
             id_format_str = "{:.0f} {:12g} {:.0f} {:.0f} {:.0f}\n"  # Refer lines 20-21
-            keys = np.array(list(self.grad_library.keys.keys()))
+            keys = np.array(list(self.grad_library.data.keys()))
             for k in keys[arb_grad_mask]:
                 s = id_format_str.format(
                     k,
@@ -132,7 +131,7 @@ def write(self, file_name: str, create_signature) -> None:
             output_file.write("# id amplitude rise flat fall delay\n")
             output_file.write("# ..      Hz/m   us   us   us    us\n")
             output_file.write("[TRAP]\n")
-            keys = np.array(list(self.grad_library.keys.keys()))
+            keys = np.array(list(self.grad_library.data.keys()))
             id_format_str = "{:2g} {:12g} {:3g} {:4g} {:3g} {:3g}\n"
             for k in keys[trap_grad_mask]:
                 data = np.copy(
@@ -148,22 +147,21 @@ def write(self, file_name: str, create_signature) -> None:
                 output_file.write(s)
             output_file.write("\n")
 
-        if len(self.adc_library.keys) != 0:
+        if len(self.adc_library.data) != 0:
             output_file.write("# Format of ADC events:\n")
             output_file.write("# id num dwell delay freq phase\n")
             output_file.write("# ..  ..    ns    us   Hz   rad\n")
             output_file.write("[ADC]\n")
-            keys = self.adc_library.keys
             id_format_str = (
                 "{:.0f} {:.0f} {:.0f} {:.0f} {:g} {:g}\n"  # Refer lines 20-21
             )
-            for k in keys.values():
+            for k in self.adc_library.data:
                 data = np.multiply(self.adc_library.data[k][0:5], [1, 1e9, 1e6, 1, 1])
                 s = id_format_str.format(k, *data)
                 output_file.write(s)
             output_file.write("\n")
 
-        if len(self.extensions_library.keys) != 0:
+        if len(self.extensions_library.data) != 0:
             output_file.write("# Format of extension lists:\n")
             output_file.write("# id type ref next_id\n")
             output_file.write("# next_id of 0 terminates the list\n")
@@ -171,14 +169,13 @@ def write(self, file_name: str, create_signature) -> None:
                 "# Extension list is followed by extension specifications\n"
             )
             output_file.write("[EXTENSIONS]\n")
-            keys = self.extensions_library.keys
             id_format_str = "{:.0f} {:.0f} {:.0f} {:.0f}\n"  # Refer lines 20-21
-            for k in keys.values():
+            for k in self.extensions_library.data:
                 s = id_format_str.format(k, *np.round(self.extensions_library.data[k]))
                 output_file.write(s)
             output_file.write("\n")
 
-        if len(self.trigger_library.keys) != 0:
+        if len(self.trigger_library.data) != 0:
             output_file.write(
                 "# Extension specification for digital output and input triggers:\n"
             )
@@ -186,25 +183,23 @@ def write(self, file_name: str, create_signature) -> None:
             output_file.write(
                 f'extension TRIGGERS {self.get_extension_type_ID("TRIGGERS")}\n'
             )
-            keys = self.trigger_library.keys
             id_format_str = "{:.0f} {:.0f} {:.0f} {:.0f} {:.0f}\n"  # Refer lines 20-21
-            for k in keys.values():
+            for k in self.trigger_library.data:
                 s = id_format_str.format(
                     k, *np.round(self.trigger_library.data[k] * np.array([1, 1, 1e6, 1e6]))
                 )
                 output_file.write(s)
             output_file.write("\n")
 
-        if len(self.label_set_library.keys) != 0:
+        if len(self.label_set_library.data) != 0:
             labels = get_supported_labels()
 
             output_file.write("# Extension specification for setting labels:\n")
             output_file.write("# id set labelstring\n")
             tid = self.get_extension_type_ID("LABELSET")
             output_file.write(f"extension LABELSET {tid}\n")
-            keys = self.label_set_library.keys
             id_format_str = "{:.0f} {:.0f} {}\n"  # Refer lines 20-21
-            for k in keys.values():
+            for k in self.label_set_library.data:
                 value = self.label_set_library.data[k][0]
                 label_id = labels[
                     int(self.label_set_library.data[k][1]) - 1
@@ -217,9 +212,8 @@ def write(self, file_name: str, create_signature) -> None:
             output_file.write("# id set labelstring\n")
             tid = self.get_extension_type_ID("LABELINC")
             output_file.write(f"extension LABELINC {tid}\n")
-            keys = self.label_inc_library.keys
             id_format_str = "{:.0f} {:.0f} {}\n"  # See comment at the beginning of this method definition
-            for k in keys.values():
+            for k in self.label_inc_library.data:
                 value = self.label_inc_library.data[k][0]
                 label_id = labels[
                     self.label_inc_library.data[k][1] - 1
@@ -228,11 +222,10 @@ def write(self, file_name: str, create_signature) -> None:
                 output_file.write(s)
             output_file.write("\n")
 
-        if len(self.shape_library.keys) != 0:
+        if len(self.shape_library.data) != 0:
             output_file.write("# Sequence Shapes\n")
             output_file.write("[SHAPES]\n\n")
-            keys = self.shape_library.keys
-            for k in keys.values():
+            for k in self.shape_library.data:
                 shape_data = self.shape_library.data[k]
                 s = "shape_id {:.0f}\n".format(k)
                 output_file.write(s)

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -63,9 +63,9 @@ def write(self, file_name: str, create_signature) -> None:
         output_file.write("[BLOCKS]\n")
         id_format_width = "{:" + str(len(str(len(self.block_events)))) + "d}"
         id_format_str = id_format_width + " {:3d} {:3d} {:3d} {:3d} {:3d} {:2d} {:2d}\n"
-        for block_counter in range(len(self.block_events)):
+        for block_counter in self.block_events:
             block_duration = (
-                self.block_durations[block_counter + 1] / self.block_duration_raster
+                self.block_durations[block_counter] / self.block_duration_raster
             )
             block_duration_rounded = round(block_duration)
 
@@ -73,9 +73,9 @@ def write(self, file_name: str, create_signature) -> None:
 
             s = id_format_str.format(
                 *(
-                    block_counter + 1,
+                    block_counter,
                     block_duration_rounded,
-                    *self.block_events[block_counter + 1][1:],
+                    *self.block_events[block_counter][1:],
                 )
             )
             output_file.write(s)

--- a/pypulseq/add_gradients.py
+++ b/pypulseq/add_gradients.py
@@ -17,7 +17,7 @@ def add_gradients(
     grads: Iterable[SimpleNamespace],
     max_grad: int = 0,
     max_slew: int = 0,
-    system=Opts(),
+    system=None,
 ) -> SimpleNamespace:
     """
     Returns the superposition of several gradients.
@@ -38,6 +38,9 @@ def add_gradients(
     grad : SimpleNamespace
         Superimposition of gradient events from `grads`.
     """
+    if system == None:
+        system = Opts.default
+        
     if max_grad <= 0:
         max_grad = system.max_grad
     if max_slew <= 0:

--- a/pypulseq/add_ramps.py
+++ b/pypulseq/add_ramps.py
@@ -13,7 +13,7 @@ def add_ramps(
     max_grad: int = 0,
     max_slew: int = 0,
     rf: SimpleNamespace = None,
-    system=Opts(),
+    system=None,
 ) -> List[np.ndarray]:
     """
     Add segments to the trajectory to ramp to and from the given trajectory.
@@ -45,6 +45,9 @@ def add_ramps(
     RuntimeError
         If gradient ramps fail to be calculated
     """
+    if system == None:
+        system = Opts.default
+        
     if not isinstance(k, (list, np.ndarray, tuple)):
         raise ValueError(
             f"k has to be one of list, np.ndarray, tuple. Passed: {type(k)}"
@@ -52,9 +55,11 @@ def add_ramps(
 
     k_arg = copy(k)
     if max_grad > 0:
+        system = copy(system)
         system.max_grad = max_grad
 
     if max_slew > 0:
+        system = copy(system)
         system.max_slew = max_slew
 
     k = np.vstack(k)

--- a/pypulseq/calc_ramp.py
+++ b/pypulseq/calc_ramp.py
@@ -11,7 +11,7 @@ def calc_ramp(
     max_grad: np.ndarray = np.zeros(0),
     max_points: int = 500,
     max_slew: np.ndarray = np.zeros(0),
-    system: Opts = Opts(),
+    system: Opts = None,
 ) -> Tuple[np.ndarray, bool]:
     """
     Join the points `k0` and `k_end` in three-dimensional  k-space in minimal time, observing the gradient and slew
@@ -42,6 +42,8 @@ def calc_ramp(
     success : bool
         Boolean flag indicating if `k0` and `k_end` were successfully joined.
     """
+    if system == None:
+        system = Opts.default
 
     def __inside_limits(grad, slew):
         if mode == 0:

--- a/pypulseq/event_lib.py
+++ b/pypulseq/event_lib.py
@@ -9,7 +9,6 @@ class EventLibrary:
     Defines an event library ot maintain a list of events. Provides methods to insert new data and find existing data.
 
     Sequence Properties:
-    - keys - A list of event IDs
     - data - A struct array with field 'array' to store data of varying lengths, remaining compatible with codegen.
     - lengths - Corresponding lengths of the data arrays
     - type - Type to distinguish events in the same class (e.g. trapezoids and arbitrary gradients)
@@ -22,12 +21,8 @@ class EventLibrary:
 
     Attributes
     ----------
-    keys : dict{str, int}
-        Key-value pairs of event keys and corresponding... event keys.
     data : dict{str: numpy.array}
         Key-value pairs of event keys and corresponding data.
-    lengths : dict{str, int}
-        Key-value pairs of event keys and corresponding length of data values in `self.data`.
     type : dict{str, str}
         Key-value pairs of event keys and corresponding event types.
     keymap : dict{str, int}
@@ -35,7 +30,6 @@ class EventLibrary:
     """
 
     def __init__(self, numpy_data=False):
-        self.keys = dict()
         self.data = dict()
         self.type = dict()
         self.keymap = dict()
@@ -44,7 +38,6 @@ class EventLibrary:
 
     def __str__(self) -> str:
         s = "EventLibrary:"
-        s += "\nkeys: " + str(len(self.keys))
         s += "\ndata: " + str(len(self.data))
         s += "\ntype: " + str(len(self.type))
         return s
@@ -75,7 +68,7 @@ class EventLibrary:
             key_id = self.keymap[key]
             found = True
         else:
-            key_id = 1 if len(self.keys) == 0 else self.next_free_ID
+            key_id = self.next_free_ID
             found = False
 
         return key_id, found
@@ -119,7 +112,6 @@ class EventLibrary:
             found = False
 
             # Insert
-            self.keys[key_id] = key_id
             self.data[key_id] = new_data
 
             if data_type != str():
@@ -163,7 +155,6 @@ class EventLibrary:
         else:
             key = tuple(new_data)
         
-        self.keys[key_id] = key_id
         self.data[key_id] = new_data
         if data_type != str():
             self.type[key_id] = data_type
@@ -187,7 +178,7 @@ class EventLibrary:
         dict
         """
         return {
-            "key": self.keys[key_id],
+            "key": key_id,
             "data": self.data[key_id],
             "type": self.type[key_id],
         }
@@ -207,7 +198,7 @@ class EventLibrary:
         out : SimpleNamespace
         """
         out = SimpleNamespace()
-        out.key = self.keys[key_id]
+        out.key = key_id
         out.data = self.data[key_id]
         out.type = self.type[key_id]
 
@@ -224,17 +215,12 @@ class EventLibrary:
         Parameters
         ----------
         key_id : int
-        old_data : numpy.ndarray
+        old_data : numpy.ndarray (Ignored!)
         new_data : numpy.ndarray
         data_type : str, default=str()
         """
-        if len(self.keys) >= key_id:
-            if self.numpy_data:
-                old_data = np.asarray(old_data)
-                key = old_data.tobytes()
-            else:
-                key = tuple(old_data)
-            del self.keymap[key]
+        if key_id in self.data:
+            del self.keymap[self.data[key_id]]
 
         self.insert(key_id, new_data, data_type)
 
@@ -249,7 +235,7 @@ class EventLibrary:
         Parameters
         ----------
         key_id : int
-        old_data : np.ndarray
+        old_data : np.ndarray (Ignored!)
         new_data : np.ndarray
         data_type : str
         """

--- a/pypulseq/make_adc.py
+++ b/pypulseq/make_adc.py
@@ -10,7 +10,7 @@ def make_adc(
     dwell: float = 0,
     freq_offset: float = 0,
     phase_offset: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
 ) -> SimpleNamespace:
     """
     Create an ADC readout event.
@@ -42,6 +42,9 @@ def make_adc(
     ValueError
         If neither `dwell` nor `duration` are defined.
     """
+    if system == None:
+        system = Opts.default
+        
     adc = SimpleNamespace()
     adc.type = "adc"
     adc.num_samples = num_samples

--- a/pypulseq/make_adiabatic_pulse.py
+++ b/pypulseq/make_adiabatic_pulse.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import Tuple, Union
+from copy import copy
 
 import numpy as np
 import math
@@ -31,7 +32,7 @@ def make_adiabatic_pulse(
     return_gz: bool = False,
     return_delay: bool = False,
     slice_thickness: float = 0,
-    system=Opts(),
+    system=None,
     use: str = str(),
 ) -> Union[
     SimpleNamespace,
@@ -135,6 +136,9 @@ def make_adiabatic_pulse(
         If invalid pulse use is encountered.
         If slice thickness is not provided but slice-selective trapezoid event is expected.
     """
+    if system == None:
+        system = Opts.default
+        
     valid_pulse_types = ["hypsec", "wurst"]
     if pulse_type != "" and pulse_type not in valid_pulse_types:
         raise ValueError(
@@ -218,9 +222,11 @@ def make_adiabatic_pulse(
             raise ValueError("Slice thickness must be provided")
 
         if max_grad > 0:
+            system = copy(system)
             system.max_grad = max_grad
 
         if max_slew > 0:
+            system = copy(system)
             system.max_slew = max_slew
 
         if pulse_type == "hypsec":

--- a/pypulseq/make_arbitrary_grad.py
+++ b/pypulseq/make_arbitrary_grad.py
@@ -11,7 +11,7 @@ def make_arbitrary_grad(
     delay: float = 0,
     max_grad: float = 0,
     max_slew: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
 ) -> SimpleNamespace:
     """
     Creates a gradient event with arbitrary waveform.
@@ -45,6 +45,9 @@ def make_arbitrary_grad(
         If slew rate is violated.
         If gradient amplitude is violated.
     """
+    if system == None:
+        system = Opts.default
+        
     if channel not in ["x", "y", "z"]:
         raise ValueError(
             f"Invalid channel. Must be one of x, y or z. Passed: {channel}"

--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import Tuple, Union
+from copy import copy
 
 import numpy as np
 import math
@@ -26,7 +27,7 @@ def make_arbitrary_rf(
     return_delay: bool = False,
     return_gz: bool = False,
     slice_thickness: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     time_bw_product: float = 0,
     use: str = str(),
 ) -> Union[SimpleNamespace, Tuple[SimpleNamespace, SimpleNamespace]]:
@@ -83,6 +84,9 @@ def make_arbitrary_rf(
         If `signal` with ndim > 1 is passed.
         If `return_gz=True`, and `slice_thickness` and `bandwidth` are not passed.
     """
+    if system == None:
+        system = Opts.default
+        
     valid_use_pulses = get_supported_rf_uses()
     if use != "" and use not in valid_use_pulses:
         raise ValueError(
@@ -127,8 +131,10 @@ def make_arbitrary_rf(
             raise ValueError("Bandwidth of pulse must be provided.")
 
         if max_grad > 0:
+            system = copy(system)
             system.max_grad = max_grad
         if max_slew > 0:
+            system = copy(system)
             system.max_slew = max_slew
 
         BW = bandwidth

--- a/pypulseq/make_block_pulse.py
+++ b/pypulseq/make_block_pulse.py
@@ -19,7 +19,7 @@ def make_block_pulse(
     freq_offset: float = 0,
     phase_offset: float = 0,
     return_delay: bool = False,
-    system: Opts = Opts(),
+    system: Opts = None,
     use: str = str(),
 ) -> Union[SimpleNamespace, Tuple[SimpleNamespace, SimpleNamespace]]:
     """
@@ -67,6 +67,9 @@ def make_block_pulse(
         One of bandwidth or duration must be defined, but not both.
         One of bandwidth or duration must be defined and be > 0.
     """
+    if system == None:
+        system = Opts.default
+        
     valid_use_pulses = get_supported_rf_uses()
     if use != "" and use not in valid_use_pulses:
         raise ValueError(

--- a/pypulseq/make_digital_output_pulse.py
+++ b/pypulseq/make_digital_output_pulse.py
@@ -4,7 +4,7 @@ from pypulseq.opts import Opts
 
 
 def make_digital_output_pulse(
-    channel: str, delay: float = 0, duration: float = 4e-3, system: Opts = Opts()
+    channel: str, delay: float = 0, duration: float = 4e-3, system: Opts = None
 ) -> SimpleNamespace:
     """
     Create a digital output pulse event a.k.a. trigger. Creates an output trigger event on a given channel with optional
@@ -31,6 +31,9 @@ def make_digital_output_pulse(
     ValueError
         If `channel` is invalid. Must be one of 'osc0','osc1', or 'ext1'.
     """
+    if system == None:
+        system = Opts.default
+        
     if channel not in ["osc0", "osc1", "ext1"]:
         raise ValueError(
             f"Channel {channel} is invalid. Must be one of 'osc0','osc1', or 'ext1'."

--- a/pypulseq/make_extended_trapezoid.py
+++ b/pypulseq/make_extended_trapezoid.py
@@ -15,7 +15,7 @@ def make_extended_trapezoid(
     max_grad: float = 0,
     max_slew: float = 0,
     skip_check: bool = False,
-    system: Opts = Opts(),
+    system: Opts = None,
     times: np.ndarray = np.zeros(1),
 ) -> SimpleNamespace:
     """
@@ -60,6 +60,9 @@ def make_extended_trapezoid(
         If all elements in `amplitudes` are zero.
         If first amplitude of a gradient is non-ero and does not connect to a previous block.
     """
+    if system == None:
+        system = Opts.default
+        
     if channel not in ["x", "y", "z"]:
         raise ValueError(
             f"Invalid channel. Must be one of 'x', 'y' or 'z'. Passed: {channel}"

--- a/pypulseq/make_gauss_pulse.py
+++ b/pypulseq/make_gauss_pulse.py
@@ -1,6 +1,7 @@
 import math
 from types import SimpleNamespace
 from typing import Tuple, Union
+from copy import copy
 
 import numpy as np
 
@@ -26,7 +27,7 @@ def make_gauss_pulse(
     return_gz: bool = False,
     return_delay: bool = False,
     slice_thickness: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     time_bw_product: float = 4,
     use: str = str(),
 ) -> Union[
@@ -93,6 +94,9 @@ def make_gauss_pulse(
         If invalid `use` is passed.
         If `return_gz=True` and `slice_thickness` was not passed.
     """
+    if system == None:
+        system = Opts.default
+        
     if use != "" and use not in get_supported_rf_uses():
         raise ValueError(
             f"Invalid use parameter. Must be one of {get_supported_rf_uses()}. Passed: {use}"
@@ -135,9 +139,11 @@ def make_gauss_pulse(
             raise ValueError("Slice thickness must be provided")
 
         if max_grad > 0:
+            system = copy(system)
             system.max_grad = max_grad
 
         if max_slew > 0:
+            system = copy(system)
             system.max_slew = max_slew
 
         amplitude = BW / slice_thickness

--- a/pypulseq/make_sigpy_pulse.py
+++ b/pypulseq/make_sigpy_pulse.py
@@ -1,6 +1,7 @@
 import math
 from types import SimpleNamespace
 from typing import Tuple, Union
+from copy import copy
 
 import numpy as np
 import sigpy.mri.rf as rf
@@ -22,7 +23,7 @@ def sigpy_n_seq(
     phase_offset: float = 0,
     return_gz: bool = True,
     slice_thickness: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     time_bw_product: float = 4,
     pulse_cfg: SigpyPulseOpts = SigpyPulseOpts(),
     use: str = str(),
@@ -81,7 +82,9 @@ def sigpy_n_seq(
         If invalid `use` parameter was passed. Must be one of 'excitation', 'refocusing' or 'inversion'.
         If `return_gz=True` and `slice_thickness` was not provided.
     """
-
+    if system == None:
+        system = Opts.default
+        
     valid_use_pulses = ["excitation", "refocusing", "inversion"]
     if use != "" and use not in valid_use_pulses:
         raise ValueError(
@@ -128,9 +131,11 @@ def sigpy_n_seq(
             raise ValueError("Slice thickness must be provided")
 
         if max_grad > 0:
+            system = copy(system)
             system.max_grad = max_grad
 
         if max_slew > 0:
+            system = copy(system)
             system.max_slew = max_slew
         BW = time_bw_product / duration
         amplitude = BW / slice_thickness
@@ -172,10 +177,13 @@ def make_slr(
     flip_angle: float,
     time_bw_product: float = 4,
     duration: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     pulse_cfg: SigpyPulseOpts = SigpyPulseOpts(),
     disp: bool = False,
 ):
+    if system == None:
+        system = Opts.default
+        
     N = int(round(duration / 1e-6))
     t = np.arange(1, N + 1) * system.rf_raster_time
 
@@ -220,10 +228,13 @@ def make_sms(
     flip_angle: float,
     time_bw_product: float = 4,
     duration: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     pulse_cfg: SigpyPulseOpts = SigpyPulseOpts(),
     disp: bool = False,
 ):
+    if system == None:
+        system = Opts.default
+        
     N = int(round(duration / 1e-6))
     t = np.arange(1, N + 1) * system.rf_raster_time
 

--- a/pypulseq/make_sinc_pulse.py
+++ b/pypulseq/make_sinc_pulse.py
@@ -1,6 +1,7 @@
 import math
 from types import SimpleNamespace
 from typing import Tuple, Union
+from copy import copy
 
 import numpy as np
 
@@ -24,7 +25,7 @@ def make_sinc_pulse(
     return_delay: bool = False,
     return_gz: bool = False,
     slice_thickness: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
     time_bw_product: float = 4,
     use: str = str(),
 ) -> Union[
@@ -88,6 +89,9 @@ def make_sinc_pulse(
         If invalid `use` parameter was passed. Must be one of 'excitation', 'refocusing' or 'inversion'.
         If `return_gz=True` and `slice_thickness` was not provided.
     """
+    if system == None:
+        system = Opts.default
+        
     valid_pulse_uses = get_supported_rf_uses()
     if use != "" and use not in valid_pulse_uses:
         raise ValueError(
@@ -132,9 +136,11 @@ def make_sinc_pulse(
             raise ValueError("Slice thickness must be provided")
 
         if max_grad > 0:
+            system = copy(system)
             system.max_grad = max_grad
 
         if max_slew > 0:
+            system = copy(system)
             system.max_slew = max_slew
 
         amplitude = BW / slice_thickness

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -47,7 +47,7 @@ def make_trapezoid(
     max_grad: float = 0,
     max_slew: float = 0,
     rise_time: float = 0,
-    system: Opts = Opts(),
+    system: Opts = None,
 ) -> SimpleNamespace:
     """
     Create a trapezoidal gradient event.
@@ -104,6 +104,9 @@ def make_trapezoid(
         If `flat_time`, `duration` and `area` are not supplied.
         Amplitude violation
     """
+    if system == None:
+        system = Opts.default
+        
     if channel not in ["x", "y", "z"]:
         raise ValueError(
             f"Invalid channel. Must be one of `x`, `y` or `z`. Passed: {channel}"

--- a/pypulseq/make_trigger.py
+++ b/pypulseq/make_trigger.py
@@ -6,7 +6,7 @@ from pypulseq.opts import Opts
 
 
 def make_trigger(
-    channel: str, delay: float = 0, duration: float = 0, system: Opts = Opts()
+    channel: str, delay: float = 0, duration: float = 0, system: Opts = None
 ) -> SimpleNamespace:
     """
      Create a trigger halt event for a synchronisation with an external signal from a given channel with an optional
@@ -36,7 +36,9 @@ def make_trigger(
      ValueError
          If invalid `channel` is passed. Must be one of 'physio1' or 'physio2'.
     """
-
+    if system == None:
+        system = Opts.default
+        
     if channel not in ["physio1", "physio2"]:
         raise ValueError(
             f"Channel {channel} is invalid. Must be one of 'physio1' or 'physio2'."

--- a/pypulseq/opts.py
+++ b/pypulseq/opts.py
@@ -131,6 +131,20 @@ class Opts:
     def set_as_default(self):
         Opts.default = self
     
+    @classmethod
+    def reset_default(cls):
+        cls.default = Opts(max_grad=convert(from_value=40, from_unit="mT/m"),
+                           max_slew=convert(from_value=170, from_unit="T/m/s"),
+                           rf_dead_time=0,
+                           rf_ringdown_time=0,
+                           adc_dead_time=0,
+                           adc_raster_time=100e-9,
+                           rf_raster_time=1e-6,
+                           grad_raster_time=10e-6,
+                           block_duration_raster=10e-6,
+                           gamma=42576000,
+                           B0=1.5)
+
     def __str__(self) -> str:
         """
         Print a string representation of the system limits objects.
@@ -141,14 +155,4 @@ class Opts:
         s = "System limits:\n" + s
         return s
 
-Opts.default = Opts(max_grad=convert(from_value=40, from_unit="mT/m"),
-                    max_slew=convert(from_value=170, from_unit="T/m/s"),
-                    rf_dead_time=0,
-                    rf_ringdown_time=0,
-                    adc_dead_time=0,
-                    adc_raster_time=100e-9,
-                    rf_raster_time=1e-6,
-                    grad_raster_time=10e-6,
-                    block_duration_raster=10e-6,
-                    gamma=42576000,
-                    B0=1.5)
+Opts.reset_default()

--- a/pypulseq/opts.py
+++ b/pypulseq/opts.py
@@ -4,20 +4,27 @@ from pypulseq.convert import convert
 class Opts:
     """
     System limits of an MR scanner.
+    
+    Note: Default values can be overwritten by creating an Opts object and
+    calling `set_as_default`.
 
     Attributes
     ----------
     adc_dead_time : float, default=0
         Dead time for ADC readout pulses.
+    adc_raster_time : float, default=100e-9
+        Raster time for ADC readout pulses.
+    block_duration_raster : float, default=10e-6
+        Raster time for block durations.
     gamma : float, default=42.576e6
         Gyromagnetic ratio. Default gamma is specified for Hydrogen.
     grad_raster_time : float, default=10e-6
         Raster time for gradient waveforms.
     grad_unit : str, default='Hz/m'
         Unit of maximum gradient amplitude. Must be one of 'Hz/m', 'mT/m' or 'rad/ms/mm'.
-    max_grad : float, default=0
+    max_grad : float, default=40 mT/m
         Maximum gradient amplitude.
-    max_slew : float, default=0
+    max_slew : float, default=170 T/m/s
         Maximum slew rate.
     rf_dead_time : float, default=0
         Dead time for radio-frequency pulses.
@@ -29,6 +36,8 @@ class Opts:
         Rise time for gradients.
     slew_unit : str, default='Hz/m/s'
         Unit of maximum slew rate. Must be one of 'Hz/m/s', 'mT/m/ms', 'T/m/s' or 'rad/ms/mm/ms'.
+    B0 : float, default=1.5
+        Main magnetic field strength (in tesla)
 
     Raises
     ------
@@ -36,23 +45,22 @@ class Opts:
         If invalid `grad_unit` is passed. Must be one of 'Hz/m', 'mT/m' or 'rad/ms/mm'.
         If invalid `slew_unit` is passed. Must be one of 'Hz/m/s', 'mT/m/ms', 'T/m/s' or 'rad/ms/mm/ms'.
     """
-
     def __init__(
         self,
-        adc_dead_time: float = 0,
-        adc_raster_time: float = 100e-9,
-        block_duration_raster: float = 10e-6,
-        gamma: float = 42.576e6,
-        grad_raster_time: float = 10e-6,
+        adc_dead_time: float = None,
+        adc_raster_time: float = None,
+        block_duration_raster: float = None,
+        gamma: float = None,
+        grad_raster_time: float = None,
         grad_unit: str = "Hz/m",
-        max_grad: float = 0,
-        max_slew: float = 0,
-        rf_dead_time: float = 0,
-        rf_raster_time: float = 1e-6,
-        rf_ringdown_time: float = 0,
-        rise_time: float = 0,
+        max_grad: float = None,
+        max_slew: float = None,
+        rf_dead_time: float = None,
+        rf_raster_time: float = None,
+        rf_ringdown_time: float = None,
+        rise_time: float = None,
         slew_unit: str = "Hz/m/s",
-        B0: float = 1.5,
+        B0: float = None,
     ):
         valid_grad_units = ["Hz/m", "mT/m", "rad/ms/mm"]
         valid_slew_units = ["Hz/m/s", "mT/m/ms", "T/m/s", "rad/ms/mm/ms"]
@@ -69,22 +77,43 @@ class Opts:
                 f"Passed: {slew_unit}"
             )
 
-        if max_grad == 0:
-            max_grad = convert(from_value=40, from_unit="mT/m", gamma=gamma)
-        else:
+        if gamma == None:
+            gamma = Opts.default.gamma
+
+        if max_grad != None:
             max_grad = convert(
                 from_value=max_grad, from_unit=grad_unit, to_unit="Hz/m", gamma=gamma
             )
-
-        if max_slew == 0:
-            max_slew = convert(from_value=170, from_unit="T/m/s", gamma=gamma)
         else:
+            max_grad = Opts.default.max_grad
+
+        if max_slew != None:
             max_slew = convert(
                 from_value=max_slew, from_unit=slew_unit, to_unit="Hz/m", gamma=gamma
             )
+        else:
+            max_slew = Opts.default.max_slew
 
-        if rise_time != 0:
+        if rise_time != None:
             max_slew = max_grad / rise_time
+        
+        if adc_dead_time == None:
+            adc_dead_time = Opts.default.adc_dead_time
+        if adc_raster_time == None:
+            adc_raster_time = Opts.default.adc_raster_time
+        if block_duration_raster == None:
+            block_duration_raster = Opts.default.block_duration_raster
+        
+        if rf_dead_time == None:
+            rf_dead_time = Opts.default.rf_dead_time
+        if rf_raster_time == None:
+            rf_raster_time = Opts.default.rf_raster_time
+        if grad_raster_time == None:
+            grad_raster_time = Opts.default.grad_raster_time 
+        if rf_ringdown_time == None:
+            rf_ringdown_time = Opts.default.rf_ringdown_time
+        if B0 == None:
+            B0 = Opts.default.B0
 
         self.max_grad = max_grad
         self.max_slew = max_slew
@@ -98,7 +127,10 @@ class Opts:
         self.block_duration_raster = block_duration_raster
         self.gamma = gamma
         self.B0 = B0
-
+    
+    def set_as_default(self):
+        Opts.default = self
+    
     def __str__(self) -> str:
         """
         Print a string representation of the system limits objects.
@@ -108,3 +140,15 @@ class Opts:
         s = "\n".join(s)
         s = "System limits:\n" + s
         return s
+
+Opts.default = Opts(max_grad=convert(from_value=40, from_unit="mT/m"),
+                    max_slew=convert(from_value=170, from_unit="T/m/s"),
+                    rf_dead_time=0,
+                    rf_ringdown_time=0,
+                    adc_dead_time=0,
+                    adc_raster_time=100e-9,
+                    rf_raster_time=1e-6,
+                    grad_raster_time=10e-6,
+                    block_duration_raster=10e-6,
+                    gamma=42576000,
+                    B0=1.5)

--- a/pypulseq/rotate.py
+++ b/pypulseq/rotate.py
@@ -18,7 +18,7 @@ def rotate(
     *args: SimpleNamespace,
     angle: float,
     axis: str,
-    system=Opts()
+    system=None
 ) -> List[SimpleNamespace]:
     """
     Rotates the corresponding gradient(s) about the given axis by the specified amount. Gradients parallel to the
@@ -40,6 +40,9 @@ def rotate(
     rotated_grads : [SimpleNamespace]
         Rotated gradient(s).
     """
+    if system == None:
+        system = Opts.default
+        
     axes = ["x", "y", "z"]
 
     # Cycle through the objects and rotate gradients non-parallel to the given rotation axis. Rotated gradients

--- a/pypulseq/split_gradient.py
+++ b/pypulseq/split_gradient.py
@@ -75,19 +75,19 @@ def split_gradient(
             skip_check=True,
         )
         ramp_down.delay = total_length - grad.fall_time
-        ramp_down.t = ramp_down.t * grad_raster_time
 
-        flat_top = SimpleNamespace()
-        flat_top.type = "grad"
-        flat_top.channel = channel
-        flat_top.delay = grad.delay + grad.rise_time
-        flat_top.t = np.arange(
-            step=grad_raster_time,
-            stop=ramp_down.delay - grad_raster_time - grad.delay - grad.rise_time,
+
+        times = np.array([0, grad.flat_time])
+        amplitudes = np.array([grad.amplitude, grad.amplitude])
+        
+        flat_top = make_extended_trapezoid(
+            channel=channel,
+            system=system,
+            times=times,
+            amplitudes=amplitudes,
+            skip_check=True,
         )
-        flat_top.waveform = grad.amplitude * np.ones(len(flat_top.t))
-        flat_top.first = grad.amplitude
-        flat_top.last = grad.amplitude
+        flat_top.delay = grad.delay + grad.rise_time
 
         return ramp_up, flat_top, ramp_down
     elif grad.type == "grad":

--- a/pypulseq/split_gradient.py
+++ b/pypulseq/split_gradient.py
@@ -9,7 +9,7 @@ from pypulseq.opts import Opts
 
 
 def split_gradient(
-    grad: SimpleNamespace, system: Opts = Opts()
+    grad: SimpleNamespace, system: Opts = None
 ) -> Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace]:
     """
     Splits a trapezoidal gradient into slew up, flat top and slew down. Returns the individual gradient parts (slew up,
@@ -41,6 +41,9 @@ def split_gradient(
          If arbitrary gradients are passed.
          If non-gradient event is passed.
     """
+    if system == None:
+        system = Opts.default
+        
     grad_raster_time = system.grad_raster_time
     total_length = calc_duration(grad)
 

--- a/pypulseq/split_gradient_at.py
+++ b/pypulseq/split_gradient_at.py
@@ -10,7 +10,7 @@ from pypulseq.opts import Opts
 
 
 def split_gradient_at(
-    grad: SimpleNamespace, time_point: float, system: Opts = Opts()
+    grad: SimpleNamespace, time_point: float, system: Opts = None
 ) -> Union[SimpleNamespace, Tuple[SimpleNamespace, SimpleNamespace]]:
     """
     Splits a trapezoidal gradient into two extended trapezoids defined by the cut line. Returns the two gradient parts
@@ -44,6 +44,9 @@ def split_gradient_at(
     ValueError
         If non-gradient event is passed.
     """
+    if system == None:
+        system = Opts.default
+        
     # copy() to emulate pass-by-value; otherwise passed grad is modified
     grad = deepcopy(grad)
 

--- a/pypulseq/traj_to_grad.py
+++ b/pypulseq/traj_to_grad.py
@@ -6,7 +6,7 @@ from pypulseq.opts import Opts
 
 
 def traj_to_grad(
-    k: np.ndarray, raster_time: float = Opts().grad_raster_time
+    k: np.ndarray, raster_time: float = None
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Convert k-space trajectory `k` into gradient waveform in compliance with `raster_time` gradient raster time.
@@ -25,6 +25,9 @@ def traj_to_grad(
     sr : numpy.ndarray
         Slew rate.
     """
+    if raster_time == None:
+        raster_time = Opts.default.grad_raster_time
+    
     # Compute finite difference for gradients in Hz/m
     g = (k[1:] - k[:-1]) / raster_time
     # Compute the slew rate

--- a/pypulseq/utils/siemens/asc_to_hw.py
+++ b/pypulseq/utils/siemens/asc_to_hw.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 import numpy as np
 
 
-def asc_to_hw(asc : dict) -> SimpleNamespace:
+def asc_to_hw(asc : dict, cardiac_model : bool = False) -> SimpleNamespace:
     """
     Convert ASC dictionary from readasc to SAFE hardware description.
 
@@ -10,6 +10,9 @@ def asc_to_hw(asc : dict) -> SimpleNamespace:
     ----------
     asc : dict
         ASC dictionary, see readasc
+    cardiac_model : bool
+        Whether or not to read the cardiac stimulation model instead of the
+        default PNS model (returns None if not available)
 
     Returns
     -------
@@ -27,8 +30,13 @@ def asc_to_hw(asc : dict) -> SimpleNamespace:
         asc_pns = asc['GradPatSup']['Phys']['PNS']
     else:
         asc_pns = asc
+    
+    if cardiac_model:
+        if 'GradPatSup' in asc and 'CarNS' in asc['GradPatSup']['Phys']:
+            asc_pns = asc['GradPatSup']['Phys']['CarNS']
+        else:
+            return None
 
-    #hw.look_ahead    =  1.0 # MZ: this is not a real hardware parameter but a coefficient, with which the final result is multiplied
     hw.x = SimpleNamespace()
     hw.x.tau1        = asc_pns['flGSWDTauX'][0]  # ms
     hw.x.tau2        = asc_pns['flGSWDTauX'][1]  # ms


### PR DESCRIPTION
**Bug fixes:**
- `Sequence.adc_times` gave an error when no ADC events are in the sequence.
- `Sequence.read` now clears the block cache (e.g. if there already was a sequence loaded, `read` overwrites it, and should clear the block cache), and makes sure the block cache remains valid while filling in `grad.first` and `grad.last`.
- Fixed a small issue in `Sequence.read` where `grad.last` would not be filled in correctly (a larger issue with restoring these values remains, added a TODO note).
- Fixed `split_gradient`, which didn't work before.
- Fixed various pieces of code that assumed a linear ordering in the keys of `block_events`, which fixes https://github.com/pulseq/pulseq/issues/40. One small issue remains in `set_block`, where finding the previous block would be expensive, given how often this function is called...

**Features:**
- Support for loading the cardiac PNS model in `asc_to_hw` (only available for newer scanners)
- Added `time_range` parameters for `calculate_pns` and `get_gradients`
- Added possibility to change default values in `Opts` (using `opts.set_as_default`), similar to https://github.com/pulseq/pulseq/commit/6138cc022c111b1267efa708a92c153dc03f687f. This saves having to pass a system object if it is always the same (see example below).

**Cleanups:**
- Removed unused imports from `sequence.py`
- Updated type signature of `Sequence.adc_times`
- `calculate_pns` now uses piecewise-polynomial gradients from `get_gradients`
- Removed trapezoid gradient check in `set_block` because it always passed (first and last amplitudes are always 0)
- Removed the `keys` field from `event_lib` because it was always `keys[k] = k`, and updated all references to this field to use `data` or `data.keys()` instead.
- `event_lib.update` now ignores the `old_data` argument because it was not needed in the first place (old data was just used to update the `keymap` field and can just be looked up in `data`)


**Notes:**
- Please check whether the implementation of setting default values in `Opts` is as we would want it to be:
```
pp.Opts(max_grad=80).set_as_default()
g = pp.make_trapezoid('x', area=1000)
```
Gives the same result as:
```
system = pp.Opts(max_grad=80)
g = pp.make_trapezoid('x', area=1000, system=system)
```
Compared to the implementation in Matlab:
```
system = mr.Opts(max_grad=80, 'setAsDefault',true)
```

- @btasdelen regarding your TODO regarding `update_data` in `read`: Any modification of any event library needs to clear the cache for all blocks that use the changed event. I think that users should not access and change these libraries themselves, or it should be documented that the block cache needs to be cleared when doing so (and using functions that iterate over all blocks afterwards, e.g. `calculate_kspace`). For event libraries to do this any time an update happens (`insert` can in theory also overwrite data), it would need to access the `Sequence` object and it might incur a performance hit.
- In addition to the previous point, I think it is a bit wasteful that `read` accesses all blocks using `get_block`, just to update the first/last values of arbitrary gradients.