### PR TITLE
Feature: `evaluate_labels` function in `Sequence`

### DIFF
--- a/pypulseq/Sequence/block.py
+++ b/pypulseq/Sequence/block.py
@@ -260,7 +260,7 @@ def get_block(self, block_index: int) -> SimpleNamespace:
         return self.block_cache[block_index]
 
     block = SimpleNamespace()
-    attrs = ["block_duration", "rf", "gx", "gy", "gz", "adc"]
+    attrs = ["block_duration", "rf", "gx", "gy", "gz", "adc", "label"]
     values = [None] * len(attrs)
     for att, val in zip(attrs, values):
         setattr(block, att, val)
@@ -393,7 +393,7 @@ def get_block(self, block_index: int) -> SimpleNamespace:
                 label.label = supported_labels[int(data[1] - 1)]
                 label.value = data[0]
                 # Allow for multiple labels per block
-                if hasattr(block, "label"):
+                if block.label is not None:
                     block.label[len(block.label)] = label
                 else:
                     block.label = {0: label}


### PR DESCRIPTION
This implements the `evalLabels` function from upstream pulseq: https://github.com/pulseq/pulseq/blob/125c772180f324967091dc28a0e5a6b20b96faa9/matlab/%2Bmr/%40Sequence/Sequence.m#L1056

Renamed to `evaluate_labels` to be consistent with the naming of other Sequence functions.

This function tracks labels (or label evolutions) through the sequence. Either returns the final values, or label evolutions (e.g. per block, per ADC, or whenever the label changes).

A small supporting change in `event_lib.get_block` was made to always set the `label` field in the returned block (None if no labels).