### PR TITLE
Update __init__.py to solve deprecation error

### DIFF
--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -15,7 +15,7 @@ def round_half_up(n, decimals=0):
 # =========
 # NP.FLOAT EPSILON
 # =========
-eps = np.finfo(np.float).eps
+eps = np.finfo(float).eps
 
 # =========
 # PACKAGE-LEVEL IMPORTS


### PR DESCRIPTION
Changed np.float to float to address the following depreciation error.

AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations