### PR TITLE
`remove_duplicates()` without `in_place = True` causes `signature_value` to be not updated after `write`.

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1839,5 +1839,19 @@ class Sequence:
             Boolean flag to indicate if the file has to be signed.
         remove_duplicates : bool, default=True
             Remove duplicate events from the sequence before writing
+        
+        Returns
+        -------
+        signature or None : If create_signature is True, it returns the written .seq file's signature as a string, 
+        otherwise it returns None. Note that, if remove_duplicates is True, signature belongs to the 
+        deduplicated sequences signature, and not the Sequence that is stored in the Sequence object.
         """
-        return write_seq(self, name, create_signature, remove_duplicates)
+        signature = write_seq(self, name, create_signature, remove_duplicates)
+
+        if signature is not None:
+            self.signature_type = "md5"
+            self.signature_file = "text"
+            self.signature_value = signature
+            return signature
+        else:
+            return None

--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -1825,7 +1825,7 @@ class Sequence:
 
         return all_waveforms
 
-    def write(self, name: str, create_signature: bool = True, remove_duplicates: bool = True) -> None:
+    def write(self, name: str, create_signature: bool = True, remove_duplicates: bool = True) -> Union[str, None]:
         """
         Write the sequence data to the given filename using the open file format for MR sequences.
 
@@ -1840,4 +1840,4 @@ class Sequence:
         remove_duplicates : bool, default=True
             Remove duplicate events from the sequence before writing
         """
-        write_seq(self, name, create_signature, remove_duplicates)
+        return write_seq(self, name, create_signature, remove_duplicates)

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -37,7 +37,7 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
     # If removing duplicates, make a copy of the sequence with the duplicate
     # events removed.
     if remove_duplicates:
-        self = self.remove_duplicates()
+        self = self.remove_duplicates(in_place=True)
 
     with open(file_name, "w") as output_file:
         output_file.write("# Pulseq sequence file\n")

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -7,7 +7,7 @@ import numpy as np
 from pypulseq.supported_labels_rf_use import get_supported_labels
 
 
-def write(self, file_name: Union[str, Path], create_signature, remove_duplicates=True) -> None:
+def write(self, file_name: Union[str, Path], create_signature, remove_duplicates=True) -> Union[str, None]:
     """
     Write the sequence data to the given filename using the open file format for MR sequences.
 
@@ -37,7 +37,7 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
     # If removing duplicates, make a copy of the sequence with the duplicate
     # events removed.
     if remove_duplicates:
-        self = self.remove_duplicates(in_place=True)
+        self = self.remove_duplicates()
 
     with open(file_name, "w") as output_file:
         output_file.write("# Pulseq sequence file\n")
@@ -277,3 +277,5 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
             )
             output_file.write("Type md5\n")
             output_file.write(f"Hash {md5}\n")
+
+        return md5

--- a/pypulseq/Sequence/write_seq.py
+++ b/pypulseq/Sequence/write_seq.py
@@ -21,6 +21,12 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
     remove_duplicates : bool
         Before writing, remove and remap events that would be duplicates after
         the rounding done during writing
+            
+    Returns
+    -------
+    md5 or None : If create_signature is True, it returns the written .seq file's signature as a string, 
+    otherwise it returns None. Note that, if remove_duplicates is True, signature belongs to the 
+    deduplicated sequences signature, and not the Sequence that is stored in the Sequence object.
 
     Raises
     ------
@@ -258,9 +264,6 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
             buffer = output_file.read()
 
             md5 = hashlib.md5(buffer.encode("utf-8")).hexdigest()
-            self.signature_type = "md5"
-            self.signature_file = "text"
-            self.signature_value = md5
 
         # Write signature
         with open(file_name, "a") as output_file:


### PR DESCRIPTION
Due to the copy of `Sequence` object being made when `in_place=False`, assignments to the `self` in `write()` function is done to the copy, not the original. As a result, those values are not assigned after the call returns. AFAIK, only signature only these three lines are effected:

https://github.com/imr-framework/pypulseq/blob/10820cd22921eed477e0df7569949c9b8499f7e9/pypulseq/Sequence/write_seq.py#L261-L263

As a dummy workaround, I just passed `in_place=True` to the `remove_duplicates()`, but I think that is not what we want, as it will modify the `Sequence` object, is that true? In that case, my suggestion is to rename the copy, instead of assigning it to `self`, and still assigning signatures to `self` to keep old behavior. I can make that commit if you can confirm this is the desired behavior.