### PR TITLE
feat: add TRID label (GE interpreter).

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -425,7 +425,7 @@ class Sequence:
                 dk = -k_traj[:, i_period]
                 if i_period > 0:
                     # Use nans to mark the excitation points since they interrupt the plots
-                    k_traj[:, i_period - 1] = np.NaN
+                    k_traj[:, i_period - 1] = np.nan
                 # -1 on len(i_excitation) for 0-based indexing
                 ii_next_excitation = min(len(i_excitation) - 1, ii_next_excitation + 1)
             elif (

--- a/pypulseq/supported_labels_rf_use.py
+++ b/pypulseq/supported_labels_rf_use.py
@@ -28,6 +28,7 @@ def get_supported_labels() -> Tuple[
         "PMC",                      # for MoCo/PMC Pulseq version to recognize blocks that can be prospectively corrected for motion
         "NOROT", "NOPOS", "NOSCL",  # instruct the interpreter to ignore the position, rotation or scaling of the FOV specified on the UI 
         "ONCE",                     # a 3-state flag that instructs the interpreter to alter the sequence when executing multiple repeats as follows: blocks with ONCE==0 are executed on every repetition; ONCE==1: only the first repetition; ONCE==2: only the last repetition
+        "TRID",                     # an integer ID of the TR (sequence segment) used by the GE interpreter to optimize the execution on the scanner
     )
 
 


### PR DESCRIPTION
This PR adds "TRID" label (see pulseq/pulseq@682b9f1) to allow the GE interpreter to optimize the sequence by grouping consecutive blocks, removing the dead times between them. This is required to allow accurate execution of sequences designed for Siemens systems on GE systems.