### PR TITLE
Changed `get_gradients` to actually use extrapolation in the piecewise polynomial

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -865,7 +865,7 @@ class Sequence:
             gw[1][gw[1] == -0.0] = 0.0
 
             gw_pp.append(PPoly(np.stack((np.diff(gw[1]) / np.diff(gw[0]),
-                                         gw[1][:-1])), gw[0], extrapolate=False))
+                                         gw[1][:-1])), gw[0], extrapolate=True))
         return gw_pp
 
     def mod_grad_axis(self, axis: str, modifier: int) -> None:


### PR DESCRIPTION
As title, small bug in a change I made last week, causing `nan` values in gradient lookups in PNS and gradient spectrum calculations.