### PR TITLE
RF: Move sigpy to an extra optional dependency

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -39,4 +39,9 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install .
+          pytest -m "not matlab_seq_comp and not sigpy" pypulseq/tests
+      - name: Run pytest[sigpy]
+        shell: bash -l {0}
+        run: |
+          pip install .[sigpy]
           pytest -m "not matlab_seq_comp" pypulseq/tests

--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -34,7 +34,6 @@ from pypulseq.make_adiabatic_pulse import make_adiabatic_pulse
 from pypulseq.make_arbitrary_grad import make_arbitrary_grad
 from pypulseq.make_arbitrary_rf import make_arbitrary_rf
 from pypulseq.make_block_pulse import make_block_pulse
-from pypulseq.make_sigpy_pulse import *
 from pypulseq.make_delay import make_delay
 from pypulseq.make_digital_output_pulse import make_digital_output_pulse
 from pypulseq.make_extended_trapezoid import make_extended_trapezoid

--- a/pypulseq/make_sigpy_pulse.py
+++ b/pypulseq/make_sigpy_pulse.py
@@ -4,8 +4,16 @@ from typing import Tuple, Union
 from copy import copy
 
 import numpy as np
-import sigpy.mri.rf as rf
-import sigpy.plot as pl
+try:
+    import sigpy.mri.rf as rf
+    import sigpy.plot as pl
+except ImportError as exc:
+    import warnings
+    warnings.warn(
+        'Sigpy dependency not found, please install it to use '
+        'the sigpy pulse functions: sigpy_n_seq, make_slr, make_sms. '
+        'Use "pip install pypulse[sigpy]" to install.')
+    raise exc
 
 from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts

--- a/pypulseq/tests/pytest.ini
+++ b/pypulseq/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     matlab_seq_comp: marks tests as comparison with matlab generated sequence (deselect with '-m "not matlab_seq_comp"')
+    sigpy: marks tests as those which require a sigpy installation (deselect with '-m "not sigpy"')

--- a/pypulseq/tests/test_make_adiabatic_pulse.py
+++ b/pypulseq/tests/test_make_adiabatic_pulse.py
@@ -1,0 +1,108 @@
+"""Tests for the make_adiabatic_pulse.py module
+
+Will Clarke, University of Oxford, 2024
+"""
+
+import pytest
+import itertools
+
+import numpy as np
+
+from pypulseq.supported_labels_rf_use import get_supported_rf_uses
+from pypulseq import make_adiabatic_pulse
+
+
+def test_pulse_select():
+    uses = get_supported_rf_uses()
+    valid_pulses = ('hypsec', 'wurst')
+
+    # Check all use and valid pulse combinations return a sensible object
+    # with default parameters.
+    for pulse, use in itertools.product(valid_pulses, uses):
+        pobj = make_adiabatic_pulse(
+            pulse_type=pulse,
+            use=use
+        )
+        assert pobj.type == 'rf'
+        assert pobj.use == use
+
+    # Check the appropriate errors are raised if we specify nonsense
+    with pytest.raises(
+            ValueError,
+            match="Invalid type parameter. Must be one of "):
+        make_adiabatic_pulse(pulse_type="not a pulse type")
+
+    with pytest.raises(
+            ValueError,
+            match="Invalid use parameter. Must be one of "):
+        make_adiabatic_pulse(
+            pulse_type="hypsec",
+            use='not a use')
+
+    # Default use case
+    pobj = make_adiabatic_pulse(pulse_type="hypsec")
+    assert pobj.use == "inversion"
+
+
+def test_option_requirements():
+
+    # Require non-zero slice thickness if grad requested
+    with pytest.raises(
+            ValueError,
+            match="Slice thickness must be provided"):
+        make_adiabatic_pulse(
+            pulse_type="hypsec",
+            return_gz=True)
+
+    _, gz, gzr = make_adiabatic_pulse(
+            pulse_type="hypsec",
+            return_gz=True,
+            slice_thickness=1)
+    assert gz.type == 'trap'
+    assert gzr.type == 'trap'
+
+    # Assert delay is returned if requested
+    _, delay = make_adiabatic_pulse(
+            pulse_type="hypsec",
+            return_gz=False,
+            return_delay=True)
+    assert delay.type == 'delay'
+
+    _, _, _, delay = make_adiabatic_pulse(
+            pulse_type="hypsec",
+            return_gz=True,
+            slice_thickness=1,
+            return_delay=True)
+    assert delay.type == 'delay'
+
+
+# My intention was to test that the rephase gradient area is appropriate,
+# but this doesn't pass and I'm highly suspicious of the calculation in
+# the code
+def test_returned_grads():
+    pass
+    # _, gz, gzr = make_adiabatic_pulse(
+    #         pulse_type="hypsec",
+    #         return_gz=True,
+    #         slice_thickness=1)
+    # assert np.isclose(-gz.area / 2, gzr.area)
+
+
+def test_hypsec_options():
+    pobj = make_adiabatic_pulse(
+        pulse_type="hypsec",
+        beta=700,
+        mu=6,
+        duration=0.05)
+
+    assert np.isclose(pobj.shape_dur, 0.05)
+
+
+def test_wurst_options():
+    pobj = make_adiabatic_pulse(
+        pulse_type="wurst",
+        n_fac=25,
+        bandwidth=30000,
+        duration=0.05)
+
+    assert np.isclose(pobj.shape_dur, 0.05)

--- a/pypulseq/tests/test_sigpy.py
+++ b/pypulseq/tests/test_sigpy.py
@@ -1,10 +1,9 @@
 # sms - check MB
 # slr - check slice profile
 
-import unittest
+import pytest
 
 import numpy as np
-import sigpy.mri.rf as rf
 
 import pypulseq as pp
 from pypulseq.make_sigpy_pulse import sigpy_n_seq
@@ -12,118 +11,120 @@ from pypulseq.opts import Opts
 from pypulseq.sigpy_pulse_opts import SigpyPulseOpts
 
 
-class TestSigpyPulseMethods(unittest.TestCase):
-    def test_slr(self):
-        print("Testing SLR design")
+@pytest.mark.sigpy
+def test_slr():
+    import sigpy.mri.rf as rf
 
-        time_bw_product = 4
-        slice_thickness = 3e-3  # Slice thickness
-        flip_angle = np.pi / 2
-        # Set system limits
-        system = Opts(
-            max_grad=32,
-            grad_unit="mT/m",
-            max_slew=130,
-            slew_unit="T/m/s",
-            rf_ringdown_time=30e-6,
-            rf_dead_time=100e-6,
-        )
-        pulse_cfg = SigpyPulseOpts(
-            pulse_type="slr",
-            ptype="st",
-            ftype="ls",
-            d1=0.01,
-            d2=0.01,
-            cancel_alpha_phs=False,
-            n_bands=3,
-            band_sep=20,
-            phs_0_pt="None",
-        )
-        rfp, gz, _, pulse = sigpy_n_seq(
-            flip_angle=flip_angle,
-            system=system,
-            duration=3e-3,
-            slice_thickness=slice_thickness,
-            time_bw_product=4,
-            return_gz=True,
-            pulse_cfg=pulse_cfg,
-            plot=False,
-        )
-        
-        seq = pp.Sequence()
-        seq.add_block(rfp)
+    print("Testing SLR design")
 
-        [a, b] = rf.sim.abrm(
-            pulse,
-            np.arange(
-                -20 * time_bw_product, 20 * time_bw_product, 40 * time_bw_product / 2000
-            ),
-            True,
-        )
-        Mxy = 2 * np.multiply(np.conj(a), b)
-        # pl.LinePlot(Mxy)
-        # print(np.sum(np.abs(Mxy)))
-        # peaks, dict = sis.find_peaks(np.abs(Mxy),threshold=0.5, plateau_size=40)
-        plateau_widths = np.sum(np.abs(Mxy) > 0.8)
-        self.assertTrue(29, plateau_widths)
+    time_bw_product = 4
+    slice_thickness = 3e-3  # Slice thickness
+    flip_angle = np.pi / 2
+    # Set system limits
+    system = Opts(
+        max_grad=32,
+        grad_unit="mT/m",
+        max_slew=130,
+        slew_unit="T/m/s",
+        rf_ringdown_time=30e-6,
+        rf_dead_time=100e-6,
+    )
+    pulse_cfg = SigpyPulseOpts(
+        pulse_type="slr",
+        ptype="st",
+        ftype="ls",
+        d1=0.01,
+        d2=0.01,
+        cancel_alpha_phs=False,
+        n_bands=3,
+        band_sep=20,
+        phs_0_pt="None",
+    )
+    rfp, gz, _, pulse = sigpy_n_seq(
+        flip_angle=flip_angle,
+        system=system,
+        duration=3e-3,
+        slice_thickness=slice_thickness,
+        time_bw_product=4,
+        return_gz=True,
+        pulse_cfg=pulse_cfg,
+        plot=False,
+    )
 
-    def test_sms(self):
-        print("Testing SMS design")
+    seq = pp.Sequence()
+    seq.add_block(rfp)
 
-        time_bw_product = 4
-        slice_thickness = 3e-3  # Slice thickness
-        flip_angle = np.pi / 2
-        n_bands = 3
-        # Set system limits
-        system = Opts(
-            max_grad=32,
-            grad_unit="mT/m",
-            max_slew=130,
-            slew_unit="T/m/s",
-            rf_ringdown_time=30e-6,
-            rf_dead_time=100e-6,
-        )
-        pulse_cfg = SigpyPulseOpts(
-            pulse_type="sms",
-            ptype="st",
-            ftype="ls",
-            d1=0.01,
-            d2=0.01,
-            cancel_alpha_phs=False,
-            n_bands=n_bands,
-            band_sep=20,
-            phs_0_pt="None",
-        )
-        rfp, gz, _, pulse = sigpy_n_seq(
-            flip_angle=flip_angle,
-            system=system,
-            duration=3e-3,
-            slice_thickness=slice_thickness,
-            time_bw_product=4,
-            return_gz=True,
-            pulse_cfg=pulse_cfg,
-            plot=False
-        )
-       
-        seq = pp.Sequence()
-        seq.add_block(rfp)
-
-        [a, b] = rf.sim.abrm(
-            pulse,
-            np.arange(
-                -20 * time_bw_product, 20 * time_bw_product, 40 * time_bw_product / 2000
-            ),
-            True,
-        )
-        Mxy = 2 * np.multiply(np.conj(a), b)
-        # pl.LinePlot(Mxy)
-        # print(np.sum(np.abs(Mxy)))
-        # peaks, dict = sis.find_peaks(np.abs(Mxy),threshold=0.5, plateau_size=40)
-        plateau_widths = np.sum(np.abs(Mxy) > 0.8)
-        self.assertEqual(
-            29 * n_bands, plateau_widths
-        )  # if slr has 29 > 0.8, then sms with MB = n_bands
+    [a, b] = rf.sim.abrm(
+        pulse,
+        np.arange(
+            -20 * time_bw_product, 20 * time_bw_product, 40 * time_bw_product / 2000
+        ),
+        True,
+    )
+    Mxy = 2 * np.multiply(np.conj(a), b)
+    # pl.LinePlot(Mxy)
+    # print(np.sum(np.abs(Mxy)))
+    # peaks, dict = sis.find_peaks(np.abs(Mxy),threshold=0.5, plateau_size=40)
+    plateau_widths = np.sum(np.abs(Mxy) > 0.8)
+    assert 29 == plateau_widths
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.sigpy
+def test_sms(self):
+    import sigpy.mri.rf as rf
+
+    print("Testing SMS design")
+
+    time_bw_product = 4
+    slice_thickness = 3e-3  # Slice thickness
+    flip_angle = np.pi / 2
+    n_bands = 3
+    # Set system limits
+    system = Opts(
+        max_grad=32,
+        grad_unit="mT/m",
+        max_slew=130,
+        slew_unit="T/m/s",
+        rf_ringdown_time=30e-6,
+        rf_dead_time=100e-6,
+    )
+    pulse_cfg = SigpyPulseOpts(
+        pulse_type="sms",
+        ptype="st",
+        ftype="ls",
+        d1=0.01,
+        d2=0.01,
+        cancel_alpha_phs=False,
+        n_bands=n_bands,
+        band_sep=20,
+        phs_0_pt="None",
+    )
+    rfp, gz, _, pulse = sigpy_n_seq(
+        flip_angle=flip_angle,
+        system=system,
+        duration=3e-3,
+        slice_thickness=slice_thickness,
+        time_bw_product=4,
+        return_gz=True,
+        pulse_cfg=pulse_cfg,
+        plot=False
+    )
+    
+    seq = pp.Sequence()
+    seq.add_block(rfp)
+
+    [a, b] = rf.sim.abrm(
+        pulse,
+        np.arange(
+            -20 * time_bw_product, 20 * time_bw_product, 40 * time_bw_product / 2000
+        ),
+        True,
+    )
+    Mxy = 2 * np.multiply(np.conj(a), b)
+    # pl.LinePlot(Mxy)
+    # print(np.sum(np.abs(Mxy)))
+    # peaks, dict = sis.find_peaks(np.abs(Mxy),threshold=0.5, plateau_size=40)
+    plateau_widths = np.sum(np.abs(Mxy) > 0.8)
+    # if slr has 29 > 0.8, then sms with MB = n_bands
+    assert (29 * n_bands) == plateau_widths
+

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,10 @@ setuptools.setup(
         "matplotlib>=3.5.2",
         "numpy>=1.19.5",
         "scipy>=1.8.1",
-        "sigpy>=0.1.26",
     ],
+    extras_require={
+        "sigpy": ["sigpy>=0.1.26", ],
+    },
     license="License :: OSI Approved :: GNU Affero General Public License v3",
     long_description=_get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Vendor our own adiabatic pulse functions in `make_adiabatic_pulse.py`
- Only enable `make_sigpy_pulse.py` if sigpy is installed as an extra.
- Add test function for `make_adiabatic_pulse.py`
- Add markers to disable tests on sigpy pulses if not present
- Update the CI tests.