### PR TITLE
Add area attribute for arbitrary gradients

### DIFF
--- a/pypulseq/make_arbitrary_grad.py
+++ b/pypulseq/make_arbitrary_grad.py
@@ -30,12 +30,15 @@ def make_arbitrary_grad(
         Orientation of gradient event of arbitrary shape. Must be one of `x`, `y` or `z`.
     waveform : numpy.ndarray
         Arbitrary waveform.
-    system : Opts, default=Opts()
+    system : Opts
         System limits.
-    max_grad : float, default=0
+        Will default to `pypulseq.opts.default` if not provided.
+    max_grad : float
         Maximum gradient strength.
-    max_slew : float, default=0
+        Will default to `system.max_grad` if not provided.
+    max_slew : float
         Maximum slew rate.
+        Will default to `system.max_slew` if not provided.
     delay : float, default=0
         Delay in seconds (s).
 

--- a/pypulseq/make_arbitrary_grad.py
+++ b/pypulseq/make_arbitrary_grad.py
@@ -57,16 +57,16 @@ def make_arbitrary_grad(
     if system is None:
         system = Opts.default
 
-    if max_grad is None:
+    if max_grad is None or max_grad == 0:
         max_grad = system.max_grad
 
-    if max_slew is None:
+    if max_slew is None or max_slew == 0:
         max_slew = system.max_slew
 
     if channel not in ["x", "y", "z"]:
         raise ValueError(f"Invalid channel. Must be one of x, y or z. Passed: {channel}")
 
-    slew_rate = np.squeeze(np.subtract(waveform[1:], waveform[:-1]) / system.grad_raster_time)
+    slew_rate = np.diff(waveform) / system.grad_raster_time
     if max(abs(slew_rate)) >= max_slew:
         raise ValueError(f"Slew rate violation {max(abs(slew_rate)) / max_slew * 100}")
     if max(abs(waveform)) >= max_grad:
@@ -77,7 +77,6 @@ def make_arbitrary_grad(
     grad.channel = channel
     grad.waveform = waveform
     grad.delay = delay
-    # True timing and aux shape data
     grad.tt = (np.arange(len(waveform)) + 0.5) * system.grad_raster_time
     grad.shape_dur = len(waveform) * system.grad_raster_time
     grad.first = (3 * waveform[0] - waveform[1]) * 0.5  # Extrapolate by 1/2 gradient raster

--- a/pypulseq/make_arbitrary_grad.py
+++ b/pypulseq/make_arbitrary_grad.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Union
 
 import numpy as np
 
@@ -9,12 +10,17 @@ def make_arbitrary_grad(
     channel: str,
     waveform: np.ndarray,
     delay: float = 0,
-    max_grad: float = 0,
-    max_slew: float = 0,
-    system: Opts = None,
+    max_grad: Union[float, None] = None,
+    max_slew: Union[float, None] = None,
+    system: Union[Opts, None] = None,
 ) -> SimpleNamespace:
     """
-    Creates a gradient event with arbitrary waveform.
+    Creates a gradient event from an arbitrary waveform.
+
+    Note that the sample points are assumed to be equally spaced by `system.grad_raster_time`
+    and that the given waveform values are the values in the middle of each raster interval.
+
+    The duration of the gradient is thus given by the number of samples times `system.grad_raster_time`.
 
     See also `pypulseq.Sequence.sequence.Sequence.add_block()`.
 
@@ -45,36 +51,34 @@ def make_arbitrary_grad(
         If slew rate is violated.
         If gradient amplitude is violated.
     """
-    if system == None:
+    if system is None:
         system = Opts.default
-        
-    if channel not in ["x", "y", "z"]:
-        raise ValueError(
-            f"Invalid channel. Must be one of x, y or z. Passed: {channel}"
-        )
 
-    if max_grad <= 0:
+    if max_grad is None:
         max_grad = system.max_grad
 
-    if max_slew <= 0:
+    if max_slew is None:
         max_slew = system.max_slew
 
-    g = waveform
-    slew = np.squeeze(np.subtract(g[1:], g[:-1]) / system.grad_raster_time)
-    if max(abs(slew)) >= max_slew:
-        raise ValueError(f"Slew rate violation {max(abs(slew)) / max_slew * 100}")
-    if max(abs(g)) >= max_grad:
-        raise ValueError(f"Gradient amplitude violation {max(abs(g)) / max_grad * 100}")
+    if channel not in ["x", "y", "z"]:
+        raise ValueError(f"Invalid channel. Must be one of x, y or z. Passed: {channel}")
+
+    slew_rate = np.squeeze(np.subtract(waveform[1:], waveform[:-1]) / system.grad_raster_time)
+    if max(abs(slew_rate)) >= max_slew:
+        raise ValueError(f"Slew rate violation {max(abs(slew_rate)) / max_slew * 100}")
+    if max(abs(waveform)) >= max_grad:
+        raise ValueError(f"Gradient amplitude violation {max(abs(waveform)) / max_grad * 100}")
 
     grad = SimpleNamespace()
     grad.type = "grad"
     grad.channel = channel
-    grad.waveform = g
+    grad.waveform = waveform
     grad.delay = delay
     # True timing and aux shape data
-    grad.tt = (np.arange(1, len(g) + 1) - 0.5) * system.grad_raster_time
-    grad.shape_dur = len(g) * system.grad_raster_time
-    grad.first = (3 * g[0] - g[1]) * 0.5  # Extrapolate by 1/2 gradient raster
-    grad.last = (g[-1] * 3 - g[-2]) * 0.5  # Extrapolate by 1/2 gradient raster
+    grad.tt = (np.arange(len(waveform)) + 0.5) * system.grad_raster_time
+    grad.shape_dur = len(waveform) * system.grad_raster_time
+    grad.first = (3 * waveform[0] - waveform[1]) * 0.5  # Extrapolate by 1/2 gradient raster
+    grad.last = (waveform[-1] * 3 - waveform[-2]) * 0.5  # Extrapolate by 1/2 gradient raster
+    grad.area = (waveform * system.grad_raster_time).sum()
 
     return grad


### PR DESCRIPTION
The relevant change is the introduced area attribute:
`grad.area = (waveform * system.grad_raster_time).sum()`

The rest is minor refactoring and documentation. 