### PR TITLE
Adjust eps value (floating point precision)

### DIFF
--- a/pypulseq/__init__.py
+++ b/pypulseq/__init__.py
@@ -14,9 +14,13 @@ def round_half_up(n, decimals=0):
 
 
 # =========
-# NP.FLOAT EPSILON
+# EPSILON (Precision of floating point numbers)
 # =========
-eps = np.finfo(np.float64).eps
+
+# Instead of np.finfo(np.float64).eps, which was used before, we now try to estimate our precision based on the largest
+# expected value for times, amplitudes etc (we choose 1E6) and consider another factor 10 for compounding of rounding errors.
+# We then round the value to the closest power of 10.
+eps = 10 ** np.floor(np.log10(np.spacing(1e6) * 10))  # this is 1e-9 for np.float64
 
 # =========
 # PACKAGE-LEVEL IMPORTS


### PR DESCRIPTION
As discussed in #129 with @FrankZijlstra and @btasdelen and many other issues/slack chats etc., the current value for the floating point precision `np.finfo(np.float64).eps` is only valid at the exact value of `1.0`. However, we ofen store larger values (we decided `1e6` is a reasonable upper limit for times, grad/rf amplitudes etc), leading to way worse precisions. 

I added a comment describing how we pick the new value of `eps = 1e-9` now and left the full calculation. Maybe one of both can be removed, but IMO you can never have to much documentation 😄 

In the future, we might want to define different eps values for times, gradients, rf pulses etc, but I think this value should actually cover everything without beeing to inaccurate. 