### PR TITLE
Fix direct install from GitHub repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ Homepage = "https://github.com/imr-framework/pypulseq"
 Issues = "https://github.com/imr-framework/pypulseq/issues"
 Documentation = "https://pypulseq.readthedocs.io/en/latest/"
 
-[tool.setuptools.packages.find]
-where = ["pypulseq"]
-
 [tool.setuptools.package-data]
 SAR = ["QGlobal.mat"]
 


### PR DESCRIPTION
With #195 we switched from `setup.py` to `pyproject.toml`, where we defined:

```toml
[tool.setuptools.packages.find]
where = ["pypulseq"]
```

This works fine when you install pypulseq from a local folder using `pip install .`, but not if you want to install it directly from GitHub using `pip install git+https://github.com/imr-framework/pypulseq`.

With the direct install from GitHub, no `pypulseq` package will be created, but only the modules in our pypulseq folder (like SAR, seq_examples, Sequence, ...) will be installed as packages. 

For me, removing the 2 lines above solves the problem, which makes sense IMO, because this is meant to tell setuptools where to look for our package and not which folder IS our package. Setuptools detects the src-layout, where the pypulseq folder would be in a src folder (we should switch to this layout !!!) and the flat-layout (the one we are still using) automatically. This is why we don't have to specify where to look for our package at all. 