### PR TITLE
Fix inconsistency in "return_delay" argument of RF pulses

### DIFF
--- a/pypulseq/make_adiabatic_pulse.py
+++ b/pypulseq/make_adiabatic_pulse.py
@@ -1,15 +1,12 @@
 from types import SimpleNamespace
 from typing import Tuple, Union
-from copy import copy
 from warnings import warn
 
 import numpy as np
 import math
 
 from pypulseq import eps
-from pypulseq.calc_duration import calc_duration
 from pypulseq.calc_rf_center import calc_rf_center
-from pypulseq.make_delay import make_delay
 from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_rf_uses
@@ -31,13 +28,11 @@ def make_adiabatic_pulse(
     mu: float = 4.9,
     phase_offset: float = 0,
     return_gz: bool = False,
-    return_delay: bool = False,
     slice_thickness: float = 0,
     system: Union[Opts, None] = None,
     use: str = str(),
 ) -> Union[
     SimpleNamespace,
-    Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, SimpleNamespace],
     Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace],
 ]:
     """
@@ -109,8 +104,6 @@ def make_adiabatic_pulse(
         Power to exponentiate to within AM term. ~20 or greater is typical.
     phase_offset : float, default=0
         Phase offset.
-    return_delay : bool, default=False
-        Boolean flag to indicate if the delay has to be returned.
     return_gz : bool, default=False
         Boolean flag to indicate if the slice-selective gradient has to be returned.
     slice_thickness : float, default=0
@@ -127,8 +120,6 @@ def make_adiabatic_pulse(
         Slice-selective trapezoid event.
     gzr : SimpleNamespace, optional
         Slice-select rephasing trapezoid event.
-    delay : SimpleNamespace, optional
-        Delay event.
 
     Raises
     ------
@@ -264,19 +255,10 @@ def make_adiabatic_pulse(
         if rf.delay < (gz.rise_time + gz.delay):
             rf.delay = gz.rise_time + gz.delay
 
-    if rf.ringdown_time > 0:
-        delay = make_delay(calc_duration(rf) + rf.ringdown_time)
-    else:
-        delay = make_delay(calc_duration(rf))
-
     if trace_enabled():
         rf.trace = trace()
 
-    if return_gz and return_delay:
-        return rf, gz, gzr, delay
-    elif return_delay:
-        return rf, delay
-    elif return_gz:
+    if return_gz:
         return rf, gz, gzr
     else:
         return rf

--- a/pypulseq/make_arbitrary_rf.py
+++ b/pypulseq/make_arbitrary_rf.py
@@ -26,7 +26,6 @@ def make_arbitrary_rf(
     max_grad: float = 0,
     max_slew: float = 0,
     phase_offset: float = 0,
-    return_delay: bool = False,
     return_gz: bool = False,
     slice_thickness: float = 0,
     system: Union[Opts, None] = None,
@@ -58,8 +57,6 @@ def make_arbitrary_rf(
         Maximum slew rate of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
         Phase offset in Hertz (Hz).a
-    return_delay : bool, default=False
-        Boolean flag to indicate if delay has to be returned.
     return_gz : bool, default=False
         Boolean flag to indicate if slice-selective gradient has to be returned.
     slice_thickness : float, default=0
@@ -160,15 +157,10 @@ def make_arbitrary_rf(
         if rf.delay < (gz.rise_time + gz.delay):
             rf.delay = gz.rise_time + gz.delay
 
-    if rf.ringdown_time > 0 and return_delay:
-        delay = make_delay(calc_duration(rf) + rf.ringdown_time)
-
     if trace_enabled():
         rf.trace = trace()
 
-    if return_gz and return_delay:
-        return rf, gz, delay
-    elif return_gz:
+    if return_gz:
         return rf, gz
     else:
         return rf

--- a/pypulseq/make_block_pulse.py
+++ b/pypulseq/make_block_pulse.py
@@ -4,8 +4,6 @@ from warnings import warn
 
 import numpy as np
 
-from pypulseq.calc_duration import calc_duration
-from pypulseq.make_delay import make_delay
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_rf_uses
 from pypulseq.utils.tracing import trace_enabled, trace
@@ -19,10 +17,9 @@ def make_block_pulse(
     time_bw_product: float = None,
     freq_offset: float = 0,
     phase_offset: float = 0,
-    return_delay: bool = False,
     system: Union[Opts, None] = None,
     use: str = str(),
-) -> Union[SimpleNamespace, Tuple[SimpleNamespace, SimpleNamespace]]:
+) -> SimpleNamespace:
     """
     Create a block (RECT or hard) pulse.
 
@@ -47,8 +44,6 @@ def make_block_pulse(
         Frequency offset in Hertz (Hz).
     phase_offset : float, default=0
         Phase offset Hertz (Hz).
-    return_delay : bool, default=False
-        Boolean flag to indicate if the delay event has to be returned.
     system : Opts, default=Opts()
         System limits.
     use : str, default=str()
@@ -58,8 +53,6 @@ def make_block_pulse(
     -------
     rf : SimpleNamespace
         Radio-frequency block pulse event.
-    delay : SimpleNamespace, optional
-        Delay event.
 
     Raises
     ------
@@ -126,14 +119,7 @@ def make_block_pulse(
     if rf.dead_time > rf.delay:
         rf.delay = rf.dead_time
 
-    if rf.ringdown_time > 0 and return_delay:
-        warn(f'Specified RF delay {rf.delay*1e6:.2f} us is less than the dead time {rf.dead_time*1e6:.0f} us. Delay was increased to the dead time.', stacklevel=2)
-        delay = make_delay(calc_duration(rf) + rf.ringdown_time)
-
     if trace_enabled():
         rf.trace = trace()
 
-    if return_delay:
-        return rf, delay
-    else:
-        return rf
+    return rf

--- a/pypulseq/make_gauss_pulse.py
+++ b/pypulseq/make_gauss_pulse.py
@@ -6,8 +6,6 @@ from copy import copy
 
 import numpy as np
 
-from pypulseq.calc_duration import calc_duration
-from pypulseq.make_delay import make_delay
 from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_rf_uses
@@ -27,7 +25,6 @@ def make_gauss_pulse(
     max_slew: float = 0,
     phase_offset: float = 0,
     return_gz: bool = False,
-    return_delay: bool = False,
     slice_thickness: float = 0,
     system: Union[Opts, None] = None,
     time_bw_product: float = 4,
@@ -35,7 +32,6 @@ def make_gauss_pulse(
 ) -> Union[
     SimpleNamespace,
     Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace],
-    Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, SimpleNamespace],
 ]:
     """
     Create a [optionally slice selective] Gauss pulse.
@@ -65,8 +61,6 @@ def make_gauss_pulse(
         Maximum slew rate of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
         Phase offset in Hertz (Hz).
-    return_delay : bool, default=False
-        Boolean flag to indicate if the delay event has to be returned.
     return_gz : bool, default=False
         Boolean flag to indicate if the slice-selective gradient has to be returned.
     slice_thickness : float, default=0
@@ -87,8 +81,6 @@ def make_gauss_pulse(
         Accompanying slice select trapezoidal gradient event.
     gzr : SimpleNamespace, optional
         Accompanying slice select rephasing trapezoidal gradient event.
-    delay : SimpleNamespace, optional
-        Delay event.
 
     Raises
     ------
@@ -169,9 +161,6 @@ def make_gauss_pulse(
         if rf.delay < (gz.rise_time + gz.delay):
             rf.delay = gz.rise_time + gz.delay
 
-    if rf.ringdown_time > 0 and return_delay:
-        delay = make_delay(calc_duration(rf) + rf.ringdown_time)
-
     # Following 2 lines of code are workarounds for numpy returning 3.14... for np.angle(-0.00...)
     negative_zero_indices = np.where(rf.signal == -0.0)
     rf.signal[negative_zero_indices] = 0
@@ -179,9 +168,7 @@ def make_gauss_pulse(
     if trace_enabled():
         rf.trace = trace()
 
-    if return_gz and return_delay:
-        return rf, gz, gzr, delay
-    elif return_gz:
+    if return_gz:
         return rf, gz, gzr
     else:
         return rf

--- a/pypulseq/make_sigpy_pulse.py
+++ b/pypulseq/make_sigpy_pulse.py
@@ -175,7 +175,7 @@ def sigpy_n_seq(
         rfp.trace = trace()
 
     if return_gz:
-        return rfp, gz, gzr, pulse
+        return rfp, gz, gzr
     else:
         return rfp
 

--- a/pypulseq/make_sinc_pulse.py
+++ b/pypulseq/make_sinc_pulse.py
@@ -6,7 +6,6 @@ from copy import copy
 
 import numpy as np
 
-from pypulseq import make_delay, calc_duration
 from pypulseq.make_trapezoid import make_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.supported_labels_rf_use import get_supported_rf_uses
@@ -24,7 +23,6 @@ def make_sinc_pulse(
     max_grad: float = 0,
     max_slew: float = 0,
     phase_offset: float = 0,
-    return_delay: bool = False,
     return_gz: bool = False,
     slice_thickness: float = 0,
     system: Union[Opts, None] = None,
@@ -33,7 +31,6 @@ def make_sinc_pulse(
 ) -> Union[
     SimpleNamespace,
     Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace],
-    Tuple[SimpleNamespace, SimpleNamespace, SimpleNamespace, SimpleNamespace],
 ]:
     """
     Creates a radio-frequency sinc pulse event and optionally accompanying slice select and slice select rephasing
@@ -60,8 +57,6 @@ def make_sinc_pulse(
         Maximum slew rate of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
         Phase offset in Hertz (Hz).
-    return_delay : bool, default=False
-        Boolean flag to indicate if the delay event has to be returned.
     return_gz : bool, default=False
         Boolean flag to indicate if slice-selective gradient has to be returned.
     slice_thickness : float, default=0
@@ -166,9 +161,6 @@ def make_sinc_pulse(
         if rf.delay < (gz.rise_time + gz.delay):
             rf.delay = gz.rise_time + gz.delay
 
-    if rf.ringdown_time > 0 and return_delay:
-        delay = make_delay(calc_duration(rf) + rf.ringdown_time)
-
     # Following 2 lines of code are workarounds for numpy returning 3.14... for np.angle(-0.00...)
     negative_zero_indices = np.where(rf.signal == -0.0)
     rf.signal[negative_zero_indices] = 0
@@ -176,9 +168,7 @@ def make_sinc_pulse(
     if trace_enabled():
         rf.trace = trace()
 
-    if return_gz and return_delay:
-        return rf, gz, gzr, delay
-    elif return_gz:
+    if return_gz:
         return rf, gz, gzr
     else:
         return rf

--- a/pypulseq/tests/test_make_adiabatic_pulse.py
+++ b/pypulseq/tests/test_make_adiabatic_pulse.py
@@ -66,21 +66,6 @@ def test_option_requirements():
     assert gz.type == 'trap'
     assert gzr.type == 'trap'
 
-    # Assert delay is returned if requested
-    _, delay = make_adiabatic_pulse(
-            pulse_type="hypsec",
-            return_gz=False,
-            return_delay=True)
-    assert delay.type == 'delay'
-
-    _, _, _, delay = make_adiabatic_pulse(
-            pulse_type="hypsec",
-            return_gz=True,
-            slice_thickness=1,
-            return_delay=True)
-    assert delay.type == 'delay'
-
-
 # My intention was to test that the rephase gradient area is appropriate,
 # but this doesn't pass and I'm highly suspicious of the calculation in
 # the code


### PR DESCRIPTION
This PR fixes an inconsistent behaviour of the "return_delay" argument for RF pulses. Currently, delays are returned only, if also "return_gz" is set to True, except for adiabatic pulses. However, sometimes it is useful to return a delay, even when no slice gradient is desired. The behaviour is now the same as in make_adiabatic_pulse.py

This PR also replaces the deprecated zero-filling at the end of an RF pulse for sigpy pulses by returning a delay instead.