### PR TITLE
Assert that make_trapezoid() slew rate is smaller than max_slew

### DIFF
--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -199,7 +199,11 @@ def make_trapezoid(
 
     assert (
         abs(amplitude2) / rise_time <= max_slew
-    ), f'Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) is larger than max ({max_slew:0.0f} Hz/m/s).'
+    ), f'Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) for ramp up is larger than max ({max_slew:0.0f} Hz/m/s).'
+
+    assert (
+        abs(amplitude2) / fall_time <= max_slew
+    ), f'Refined slew rate ({abs(amplitude2)/fall_time:0.0f} Hz/m/s) for ramp down is larger than max ({max_slew:0.0f} Hz/m/s).'
 
     grad = SimpleNamespace()
     grad.type = 'trap'

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -198,9 +198,9 @@ def make_trapezoid(
     ), f'Refined amplitude ({abs(amplitude2):0.0f} Hz/m) is larger than max ({max_grad:0.0f} Hz/m).'
 
     assert (
-        abs(amplitude2)/rise_time <= max_slew
-    ), f"Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) is larger than max ({max_slew:0.0f} Hz/m/s)."
-    
+        abs(amplitude2) / rise_time <= max_slew
+    ), f'Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) is larger than max ({max_slew:0.0f} Hz/m/s).'
+
     grad = SimpleNamespace()
     grad.type = 'trap'
     grad.channel = channel

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -197,6 +197,10 @@ def make_trapezoid(
         abs(amplitude2) <= max_grad
     ), f'Refined amplitude ({abs(amplitude2):0.0f} Hz/m) is larger than max ({max_grad:0.0f} Hz/m).'
 
+    assert (
+        abs(amplitude2)/rise_time <= max_slew
+    ), f"Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) is larger than max ({max_slew:0.0f} Hz/m/s)."
+    
     grad = SimpleNamespace()
     grad.type = 'trap'
     grad.channel = channel


### PR DESCRIPTION
Tries to address #213 

make_trapezoid() checks at the end if system.max_slew is exceeded. Similar to what is done with system.max_grad.