### PR TITLE
Fix slew rate ext trapezoid

### DIFF
--- a/pypulseq/make_extended_trapezoid.py
+++ b/pypulseq/make_extended_trapezoid.py
@@ -99,9 +99,16 @@ def make_extended_trapezoid(
     if max_slew <= 0:
         max_slew = system.max_slew
 
+    waveform = points_to_waveform(times=times, amplitudes=amplitudes, grad_raster_time=system.grad_raster_time)
+    slew = np.squeeze(np.subtract(waveform[1:], waveform[:-1]) / system.grad_raster_time)
+
+    if max(abs(slew)) >= max_slew:
+        raise ValueError(f"Slew rate violation {max(abs(slew)) / max_slew * 100}")
+    if max(abs(waveform)) >= max_grad:
+        raise ValueError(f"Gradient amplitude violation {max(abs(waveform)) / max_grad * 100}")      
+
     if convert_to_arbitrary:
         # Represent the extended trapezoid on the regularly sampled time grid
-        waveform = points_to_waveform(times=times, amplitudes=amplitudes, grad_raster_time=system.grad_raster_time)
         grad = make_arbitrary_grad(
             channel=channel,
             waveform=waveform,
@@ -116,7 +123,6 @@ def make_extended_trapezoid(
             raise ValueError(
                 'All time points must be on a gradient raster or "convert_to_arbitrary" option must be used.'
             )
-
         grad = SimpleNamespace()
         grad.type = 'grad'
         grad.channel = channel

--- a/pypulseq/make_trapezoid.py
+++ b/pypulseq/make_trapezoid.py
@@ -197,6 +197,10 @@ def make_trapezoid(
         abs(amplitude2) <= max_grad
     ), f'Refined amplitude ({abs(amplitude2):0.0f} Hz/m) is larger than max ({max_grad:0.0f} Hz/m).'
 
+    assert (
+        abs(amplitude2)/rise_time <= max_slew
+    ), f"Refined slew rate ({abs(amplitude2)/rise_time:0.0f} Hz/m/s) is larger than max ({max_slew:0.0f} Hz/m/s)."
+    
     grad = SimpleNamespace()
     grad.type = 'trap'
     grad.channel = channel


### PR DESCRIPTION
Tries to address #216 

`make_extended_trapezoid` checks if provided waveform exceeds `max_slew ` or `max_grad`