### PR TITLE
Add compatibility for post-release versions

### DIFF
--- a/pypulseq/Sequence/sequence.py
+++ b/pypulseq/Sequence/sequence.py
@@ -36,7 +36,7 @@ from pypulseq.supported_labels_rf_use import get_supported_labels
 from pypulseq.utils.cumsum import cumsum
 from pypulseq.utils.tracing import format_trace, trace, trace_enabled
 
-major, minor, revision = __version__.split('.')
+major, minor, revision = __version__.split('.')[:3]
 
 
 class Sequence:


### PR DESCRIPTION
Before this fix, versions like `1.4.2.post1` were leading to an error.

The fix was included in #209 as well, but this PR is buggy for me and I will close it. 