### PR TITLE
Fix decimal places for uncompressed shapes

### DIFF
--- a/src/pypulseq/compress_shape.py
+++ b/src/pypulseq/compress_shape.py
@@ -62,6 +62,6 @@ def compress_shape(decompressed_shape: np.ndarray, force_compression: bool = Fal
     if force_compression or compressed_shape.num_samples > len(v):
         compressed_shape.data = v
     else:
-        compressed_shape.data = decompressed_shape
+        compressed_shape.data = np.round(decompressed_shape / quant_factor) * quant_factor
 
     return compressed_shape


### PR DESCRIPTION
This PR fixes a problem, where uncompressed shapes get stored with too many significant digits. This could potentially lead to problems with floating point conversion and unnecessarily enlarges the file size.