### PR TITLE
Fix None check in make_arbitrary_grad

### DIFF
--- a/src/pypulseq/make_arbitrary_grad.py
+++ b/src/pypulseq/make_arbitrary_grad.py
@@ -81,10 +81,10 @@ def make_arbitrary_grad(
     if max(abs(waveform)) >= max_grad:
         raise ValueError(f'Gradient amplitude violation {max(abs(waveform)) / max_grad * 100}')
 
-    if not first:
+    if first is None:
         first = (3 * waveform[0] - waveform[1]) * 0.5  # linear extrapolation
 
-    if not last:
+    if last is None:
         last = (3 * waveform[-1] - waveform[-2]) * 0.5  # linear extrapolation
 
     grad = SimpleNamespace()


### PR DESCRIPTION
Before this fix, it was not possible to set the `first` and/or `last` attribute to `0`, because `not 0` would always be true and thus the extrapolation was executed. 