### PR TITLE
Add warning to make_block_pulse() if rf.delay is changed to rf.dead_time

### DIFF
--- a/src/pypulseq/make_block_pulse.py
+++ b/src/pypulseq/make_block_pulse.py
@@ -112,7 +112,7 @@ def make_block_pulse(
         warn(
             f'Specified RF delay {rf.delay*1e6:.2f} us is less than the dead time {rf.dead_time*1e6:.0f} us. Delay was increased to the dead time.',
             stacklevel=2,
-        )        
+        )
         rf.delay = rf.dead_time
 
     if trace_enabled():

--- a/src/pypulseq/make_block_pulse.py
+++ b/src/pypulseq/make_block_pulse.py
@@ -109,6 +109,10 @@ def make_block_pulse(
         rf.use = use
 
     if rf.dead_time > rf.delay:
+        warn(
+            f'Specified RF delay {rf.delay*1e6:.2f} us is less than the dead time {rf.dead_time*1e6:.0f} us. Delay was increased to the dead time.',
+            stacklevel=2,
+        )        
         rf.delay = rf.dead_time
 
     if trace_enabled():


### PR DESCRIPTION
This PR adds the same warning about the change of `rf.delay` to the method `make_block_pulse` as it is implemented in `make_sinc_pulse`. 

```
if rf.dead_time > rf.delay:
    warn(
        f'Specified RF delay {rf.delay*1e6:.2f} us is less than the dead time {rf.dead_time*1e6:.0f} us. Delay was increased to the dead time.',
        stacklevel=2,
    )
    rf.delay = rf.dead_time
```