### PR TITLE
Fix SAR calculation #223.

### DIFF
--- a/src/pypulseq/SAR/SAR_calc.py
+++ b/src/pypulseq/SAR/SAR_calc.py
@@ -102,8 +102,8 @@ def _SAR_from_seq(seq: Sequence, Qtmf: np.ndarray, Qhmf: np.ndarray) -> Tuple[np
             rf = block.rf
             signal = rf.signal
             # This rf could be parallel transmit as well
-            SAR_wbg[block_counter] = _calc_SAR(Qtmf, signal)
-            SAR_hg[block_counter] = _calc_SAR(Qhmf, signal)
+            SAR_wbg[block_counter - 1] = _calc_SAR(Qtmf, signal)
+            SAR_hg[block_counter - 1] = _calc_SAR(Qhmf, signal)
 
     return SAR_wbg, SAR_hg, t
 


### PR DESCRIPTION
Aligns SAR array with time array.

´´´
    for block_counter in block_events:
        block = seq.get_block(block_counter)
        block_dur = calc_duration(block)
        t[block_counter - 1] = t_prev + block_dur
        t_prev = t[block_counter - 1]
        if hasattr(block, 'rf') and block.rf is not None:  # has rf event
            rf = block.rf
            signal = rf.signal
            # This rf could be parallel transmit as well
            SAR_wbg[block_counter - 1] = _calc_SAR(Qtmf, signal) # added -1 here
            SAR_hg[block_counter - 1] = _calc_SAR(Qhmf, signal) # added -1 here
´´´