### PR TITLE
Fixes timing of GRE sequences

### DIFF
--- a/examples/scripts/write_gre.py
+++ b/examples/scripts/write_gre.py
@@ -60,14 +60,19 @@ def main(plot: bool = False, write_seq: bool = False, seq_filename: str = 'gre_p
     # Calculate timing
     delay_TE = (
         np.ceil(
-            (TE - pp.calc_duration(gx_pre) - gz.fall_time - gz.flat_time / 2 - pp.calc_duration(gx) / 2)
+            (
+                TE
+                - pp.calc_duration(gx_pre)
+                - max(gz.fall_time + gz.flat_time / 2, rf.ringdown_time + rf.shape_dur / 2)
+                - pp.calc_duration(gx) / 2
+            )
             / seq.grad_raster_time
         )
         * seq.grad_raster_time
     )
     delay_TR = (
         np.ceil(
-            (TR - pp.calc_duration(gz) - pp.calc_duration(gx_pre) - pp.calc_duration(gx) - delay_TE)
+            (TR - pp.calc_duration(gz, rf) - pp.calc_duration(gx_pre) - pp.calc_duration(gx) - delay_TE)
             / seq.grad_raster_time
         )
         * seq.grad_raster_time


### PR DESCRIPTION
The GRE sequence https://github.com/imr-framework/pypulseq/blob/0398b12bc1d86c1997ed5ad34242a22cc95003bd/examples/scripts/write_gre.py has a small TE/TR timing error if the rf.ringdown_time gets longer than the gz.fall_time. 
Taking the max() of both fixes the issue which becomes relevant for longer ringdown times or thick slices. 