### PR TITLE
Consider floating point accuracy for system specs checks

### DIFF
--- a/src/pypulseq/make_arbitrary_grad.py
+++ b/src/pypulseq/make_arbitrary_grad.py
@@ -3,6 +3,7 @@ from typing import Union
 
 import numpy as np
 
+from pypulseq import eps
 from pypulseq.opts import Opts
 from pypulseq.utils.tracing import trace, trace_enabled
 
@@ -76,9 +77,9 @@ def make_arbitrary_grad(
         raise ValueError(f'Invalid channel. Must be one of x, y or z. Passed: {channel}')
 
     slew_rate = np.diff(waveform) / system.grad_raster_time
-    if max(abs(slew_rate)) >= max_slew:
+    if max(abs(slew_rate)) > max_slew + eps:
         raise ValueError(f'Slew rate violation {max(abs(slew_rate)) / max_slew * 100}')
-    if max(abs(waveform)) >= max_grad:
+    if max(abs(waveform)) > max_grad + eps:
         raise ValueError(f'Gradient amplitude violation {max(abs(waveform)) / max_grad * 100}')
 
     if first is None:

--- a/src/pypulseq/make_extended_trapezoid_area.py
+++ b/src/pypulseq/make_extended_trapezoid_area.py
@@ -3,6 +3,7 @@ from typing import Tuple, Union
 
 import numpy as np
 
+from pypulseq import eps
 from pypulseq.make_extended_trapezoid import make_extended_trapezoid
 from pypulseq.opts import Opts
 from pypulseq.utils.cumsum import cumsum
@@ -84,7 +85,7 @@ def make_extended_trapezoid_area(
 
         # Check if gradient amplitude exceeds max_grad, if so, adjust ramp
         # times for a trapezoidal gradient with maximum slew rate.
-        if grad_start + ramp_up_time * max_slew * raster_time > max_grad:
+        if grad_start + ramp_up_time * max_slew * raster_time > max_grad + eps:
             ramp_up_time = round(_calc_ramp_time(grad_start, max_grad) / raster_time)
             ramp_down_time = round(_calc_ramp_time(grad_end, max_grad) / raster_time)
         else:
@@ -102,7 +103,7 @@ def make_extended_trapezoid_area(
 
         # Check if gradient amplitude exceeds -max_grad, if so, adjust ramp
         # times for a trapezoidal gradient with maximum slew rate.
-        if grad_start - ramp_up_time * max_slew * raster_time < -max_grad:
+        if grad_start - ramp_up_time * max_slew * raster_time < -max_grad - eps:
             ramp_up_time = round(_calc_ramp_time(grad_start, -max_grad) / raster_time)
             ramp_down_time = round(_calc_ramp_time(grad_end, -max_grad) / raster_time)
         else:

--- a/src/pypulseq/make_trapezoid.py
+++ b/src/pypulseq/make_trapezoid.py
@@ -20,7 +20,7 @@ def calculate_shortest_params_for_area(area: float, max_slew: float, max_grad: f
     effective_time = rise_time
 
     # Adjust for max gradient constraint
-    if abs(amplitude) > max_grad:
+    if abs(amplitude) > max_grad + eps:
         effective_time = math.ceil(abs(area) / max_grad / grad_raster_time) * grad_raster_time
         amplitude = area / effective_time
         rise_time = math.ceil(abs(amplitude) / max_slew / grad_raster_time) * grad_raster_time
@@ -225,15 +225,15 @@ def make_trapezoid(
     if rise_time is None and fall_time is None:
         rise_time = fall_time = calculate_shortest_rise_time(amplitude2, max_slew, system.grad_raster_time)
 
-    if abs(amplitude2) > max_grad:
+    if abs(amplitude2) > max_grad + eps:
         raise ValueError(f'Refined amplitude ({abs(amplitude2):0.0f} Hz/m) is larger than max ({max_grad:0.0f} Hz/m).')
 
-    if abs(amplitude2) / rise_time > max_slew:
+    if abs(amplitude2) / rise_time > max_slew + eps:
         raise ValueError(
             f'Refined slew rate ({abs(amplitude2) / rise_time:0.0f} Hz/m/s) for ramp up is larger than max ({max_slew:0.0f} Hz/m/s).'
         )
 
-    if abs(amplitude2) / fall_time > max_slew:
+    if abs(amplitude2) / fall_time > max_slew + eps:
         raise ValueError(
             f'Refined slew rate ({abs(amplitude2) / fall_time:0.0f} Hz/m/s) for ramp down is larger than max ({max_slew:0.0f} Hz/m/s).'
         )


### PR DESCRIPTION
Due to rounding issue checks for violating system specs in `make_trapezoid()` may fail, even though max values are not exceeded. For example the test below fails. Adding machine precision to the comparison solves the issue and fixes #267 

```
abs(amplitude2) > max_grad
125000.00000000001 > 125000
# ValueError: Refined amplitude (125000 Hz/m) is larger than max (125000 Hz/m).
```

The error can be raised using this example script

```
from pypulseq import Opts
from pypulseq import make_trapezoid

system = Opts(
    rf_dead_time=20e-6, 
    rf_ringdown_time=30e-6,
    grad_raster_time=1e-6,
    rf_raster_time=1e-6,
    block_duration_raster=1e-6,
    adc_raster_time=1e-6,
    max_grad=250e3 / 42.576e6 * 1e3,
    grad_unit='mT/m',
    max_slew=50,
    slew_unit='T/m/s',
    B0=50e-3,
    gamma=42.576e6,
)

grad = make_trapezoid(
    channel='x',
    area=140.625,
    system=system,
    max_grad=125000.0,
)

print(grad.amplitude)  # 125000.00000000001
```