### PR TITLE
Fix pytest coverage comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ test = [
   "codecov",
   "pre-commit",
   "pytest",
-  "pytest-cov",
+  "pytest-cov<6.1",
   "pytest-xdist",
 ]
 


### PR DESCRIPTION
pytest-cov 6.1 changed the layout of the coverage output and is incompatilbe with the coverage comment action we use.

This PR pins the pytest-cov version to < 6.1

Thanks to @fzimmermann89 who fixed the same thing in [https://github.com/PTB-MR/mrpro/pull/758](https://github.com/PTB-MR/mrpro/pull/758)
