### PR TITLE
Fixes timing bug in make_sigpy_pulse()

### DIFF
--- a/src/pypulseq/make_sigpy_pulse.py
+++ b/src/pypulseq/make_sigpy_pulse.py
@@ -187,11 +187,6 @@ def sigpy_n_seq(
         if rfp.delay < (gz.rise_time + gz.delay):
             rfp.delay = gz.rise_time + gz.delay
 
-    if rfp.ringdown_time > 0:
-        t_fill = np.arange(1, round(rfp.ringdown_time / 1e-6) + 1) * 1e-6
-        rfp.t = np.concatenate((rfp.t, rfp.t[-1] + t_fill))
-        rfp.signal = np.concatenate((rfp.signal, np.zeros(len(t_fill))))
-
     # Following 2 lines of code are workarounds for numpy returning 3.14... for np.angle(-0.00...)
     negative_zero_indices = np.where(rfp.signal == -0.0)
     rfp.signal[negative_zero_indices] = 0


### PR DESCRIPTION
The current implementation of `make_sigpy_pulse` produces a timing error in `seq.check_timing()` because the rf shape is extended by the rf ringdown time by zero filling inside the function. However, it seems that the sequence keeps track of the rf ringdown time separately such that is does not need to be added to the pulse shape manually. 

This PR simply removes the following lines for zero filling of the pulse shape:

```
    if rfp.ringdown_time > 0:
        t_fill = np.arange(1, round(rfp.ringdown_time / 1e-6) + 1) * 1e-6
        rfp.t = np.concatenate((rfp.t, rfp.t[-1] + t_fill))
        rfp.signal = np.concatenate((rfp.signal, np.zeros(len(t_fill))))
```

To reproduce:
```
import numpy as np
import pypulseq as pp

system = pp.Opts(
    rf_dead_time=20e-6,
    rf_ringdown_time=30e-6,
)
# Create pulse
sigpy_cfg = pp.SigpyPulseOpts(pulse_type='slr', ptype='ex')
rf1, gz1, gzr1 = pp.make_sigpy_pulse.sigpy_n_seq(
    flip_angle=90 * np.pi / 180,
    duration=1e-3,
    slice_thickness=20e-3,
    return_gz=True,
    pulse_cfg=sigpy_cfg,
    plot=False,
    system=system,
)
# Construct sequence
seq = pp.Sequence(system)
seq.add_block(rf1, gz1)
seq.add_block(pp.make_delay(0.5))
(ok, error_report) = seq.check_timing()
if ok:
    print('Timing check passed successfully')
    print('Sequence duration is: ', round(seq.duration()[0]), 's')
else:
    print('Timing check failed. Error listing follows:')
    [print(e) for e in error_report]
```

Best Helge