### PR TITLE
Fix get_gradients function for channel specific gradient delays

### DIFF
--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -270,10 +270,16 @@ class Sequence:
 
         Parameters
         ----------
-        trajectory_delay : float or list, default=0
+        trajectory_delay : float or list or numpy.ndarray, default=0
             Compensation factor in seconds (s) to align ADC and gradients in the reconstruction.
-        gradient_offset : float or list, default=0
+            If trajectory_delay is a single value, this value will be used for all gradient channels.
+            If trajectory_delay is a list or array, it is expected to have the same length as the number of gradient
+            channels and the first element is applied to the first gradient channel, the second to the second, and so on.
+        gradient_offset : float or list or numpy.ndarray, default=0
             Simulates background gradients (specified in Hz/m)
+            If gradient_offset is a single value, this value will be used for all gradient channels.
+            If gradient_offset is a list or array, it is expected to have the same length as the number of gradient
+            channels and the first element is applied to the first gradient channel, the second to the second, and so on.
 
         Returns
         -------
@@ -725,10 +731,16 @@ class Sequence:
 
         Parameters
         ----------
-        trajectory_delay : float or list, default=0
+        trajectory_delay : float or list or numpy.ndarray, default=0
             Compensation factor in seconds (s) to align ADC and gradients in the reconstruction.
-        gradient_offset : float or list, default=0
+            If trajectory_delay is a single value, this value will be used for all gradient channels.
+            If trajectory_delay is a list or array, it is expected to have the same length as the number of gradient
+            channels and the first element is applied to the first gradient channel, the second to the second, and so on.
+        gradient_offset : float or list or numpy.ndarray, default=0
             Simulates background gradients (specified in Hz/m)
+            If gradient_offset is a single value, this value will be used for all gradient channels.
+            If gradient_offset is a list or array, it is expected to have the same length as the number of gradient
+            channels and the first element is applied to the first gradient channel, the second to the second, and so on.
 
         Returns
         -------

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -749,7 +749,7 @@ class Sequence:
             gradient_delays = [trajectory_delay] * ng
         else:
             assert len(trajectory_delay) == ng  # Need to have same number of gradient channels
-            gradient_delays = trajectory_delay * ng
+            gradient_delays = trajectory_delay
 
         # Gradient offset handling
         if isinstance(gradient_offset, (int, float)):


### PR DESCRIPTION
`Sequence.calculate_kspace()` as well as `Sequence.get_gradients()` (should) support the `trajectory_delay` argument to be of type `Union[float, List[float], np.ndarray]` to be able to define individual delays for the 3 different gradient channels. However, in `Sequence.get_gradients()` there was an additional multiplication with `ng` (the number of grad channels), leading to too long lists in the case of input type list or wrong values in the case of input type np.array. 

The lines below handle the gradient_offset, where the implementation (without the multiplication with ng) is correct already. 

In the [matlab code](https://github.com/pulseq/pulseq/blob/c4ffd8250bef0a6b6f75b9e1ad275409d11b7727/matlab/%2Bmr/%40Sequence/Sequence.m#L2012) the factor is also NOT present. 

