### PR TITLE
Fix and adjust sequence.plot() method

### DIFF
--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -1027,30 +1027,45 @@ class Sequence:
                         sp12.plot(time_with_delay, np.real(signal))
 
                         # Include sign(real(signal)) factor like MATLAB
-                        phase_corrected = signal * np.sign(np.real(signal)) * np.exp(1j * rf.phase_offset) * np.exp(1j * 2 * math.pi * time * rf.freq_offset)
-                        sc_corrected = signal[index_center] * np.exp(1j * rf.phase_offset) * np.exp(1j * 2 * math.pi * time[index_center] * rf.freq_offset)
+                        phase_corrected = (
+                            signal
+                            * np.sign(np.real(signal))
+                            * np.exp(1j * rf.phase_offset)
+                            * np.exp(1j * 2 * math.pi * time * rf.freq_offset)
+                        )
+                        sc_corrected = (
+                            signal[index_center]
+                            * np.exp(1j * rf.phase_offset)
+                            * np.exp(1j * 2 * math.pi * time[index_center] * rf.freq_offset)
+                        )
 
                         sp13.plot(
                             time_with_delay,
                             np.angle(phase_corrected),
                             time_center_with_delay,
                             np.angle(sc_corrected),
-                            'xb'
+                            'xb',
                         )
                     else:
                         # Plot magnitude of complex signal
                         sp12.plot(time_with_delay, np.abs(signal))
 
                         # Plot angle of complex signal
-                        phase_corrected = signal * np.exp(1j * rf.phase_offset) * np.exp(1j * 2 * math.pi * time * rf.freq_offset)
-                        sc_corrected = signal[index_center] * np.exp(1j * rf.phase_offset) * np.exp(1j * 2 * math.pi * time[index_center] * rf.freq_offset)
+                        phase_corrected = (
+                            signal * np.exp(1j * rf.phase_offset) * np.exp(1j * 2 * math.pi * time * rf.freq_offset)
+                        )
+                        sc_corrected = (
+                            signal[index_center]
+                            * np.exp(1j * rf.phase_offset)
+                            * np.exp(1j * 2 * math.pi * time[index_center] * rf.freq_offset)
+                        )
 
                         sp13.plot(
                             time_with_delay,
                             np.angle(phase_corrected),
                             time_center_with_delay,
                             np.angle(sc_corrected),
-                            'xb'
+                            'xb',
                         )
 
                 grad_channels = ['gx', 'gy', 'gz']


### PR DESCRIPTION
The first commit fixes a "bug" where the phase of block pulses with frequency offset was not shown correctly as I described [HERE](https://github.com/pulseq/pulseq/issues/115) in the MATLAB Github repo.

While porting these changes to Python, I realized that the plots of rf pulses differ in general between Matlab and Python. The second commit adjusts the Python code the match the Matlab version. 

Here are the plots before and after the changes for my mini example including a block and a sinc pulse with identical settings...

Matlab plot showing the problem of the wrong phase visualization for block pulses with freq. offset:
![446901752-d21622a6-168e-4f7b-8724-c7e975147a72](https://github.com/user-attachments/assets/09d48724-9973-4306-b7d8-d0ca86577dd9)

Python plot showing the same problem. Compare with Matlab plot to see the mentioned general differences:
![image](https://github.com/user-attachments/assets/04ef6945-0728-41e9-be47-86ad32bf12a2)

Python plot after the phase fix and adjustments made in this PR:
![image](https://github.com/user-attachments/assets/a78d52a7-3ee1-43ed-9335-b69c7817b908)

