### PR TITLE
# [towards v1.5.x] Refactor gradient continuity check

### DIFF
--- a/src/pypulseq/Sequence/block.py
+++ b/src/pypulseq/Sequence/block.py
@@ -4,11 +4,11 @@ from typing import List, Tuple, Union
 
 import numpy as np
 
-from pypulseq import eps
 from pypulseq.block_to_events import block_to_events
 from pypulseq.compress_shape import compress_shape
 from pypulseq.decompress_shape import decompress_shape
 from pypulseq.event_lib import EventLibrary
+from pypulseq.Sequence.grad_check import grad_check
 from pypulseq.supported_labels_rf_use import get_supported_labels
 from pypulseq.utils.tracing import trace_enabled
 
@@ -46,9 +46,9 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
     duration = 0
 
     check_g = {
-        0: SimpleNamespace(idx=2, start=(0, 0), stop=(0, 0)),
-        1: SimpleNamespace(idx=3, start=(0, 0), stop=(0, 0)),
-        2: SimpleNamespace(idx=4, start=(0, 0), stop=(0, 0)),
+        0: SimpleNamespace(start=(0, 0), stop=(0, 0)),
+        1: SimpleNamespace(start=(0, 0), stop=(0, 0)),
+        2: SimpleNamespace(start=(0, 0), stop=(0, 0)),
     }  # Key-value mapping of index and  pairs of gradients/times
     extensions = []
 
@@ -190,79 +190,7 @@ def set_block(self, block_index: int, *args: SimpleNamespace) -> None:
     # =========
     # PERFORM GRADIENT CHECKS
     # =========
-    for grad_to_check in check_g.values():
-        if abs(grad_to_check.start[1]) > self.system.max_slew * self.system.grad_raster_time:  # noqa: SIM102
-            if grad_to_check.start[0] > eps:
-                raise RuntimeError('No delay allowed for gradients which start with a non-zero amplitude')
-
-        # Check whether any blocks exist in the sequence
-        if self.next_free_block_ID > 1:
-            # Look up the previous block (and the next block in case of a set_block call)
-            if block_index == self.next_free_block_ID:
-                # New block inserted
-                prev_block_index = next(reversed(self.block_events))
-                next_block_index = None
-            else:
-                blocks = list(self.block_events)
-                try:
-                    # Existing block overwritten
-                    idx = blocks.index(block_index)
-                    prev_block_index = blocks[idx - 1] if idx > 0 else None
-                    next_block_index = blocks[idx + 1] if idx < len(blocks) - 1 else None
-                except ValueError:
-                    # Inserting a new block with non-contiguous numbering
-                    prev_block_index = next(reversed(self.block_events))
-                    next_block_index = None
-
-            # Look up the last gradient value in the previous block
-            last = 0
-            if prev_block_index is not None:
-                prev_id = self.block_events[prev_block_index][grad_to_check.idx]
-                if prev_id != 0:
-                    prev_lib = self.grad_library.get(prev_id)
-                    prev_type = prev_lib['type']
-
-                    if prev_type == 't':
-                        last = 0
-                    elif prev_type == 'g':
-                        last = prev_lib['data'][5]
-
-            # Check whether the difference between the last gradient value and
-            # the first value of the new gradient is achievable with the
-            # specified slew rate.
-            if abs(last - grad_to_check.start[1]) > self.system.max_slew * self.system.grad_raster_time:
-                raise RuntimeError('Two consecutive gradients need to have the same amplitude at the connection point')
-
-            # Look up the first gradient value in the next block
-            # (this only happens when using set_block to patch a block)
-            if next_block_index is not None:
-                next_id = self.block_events[next_block_index][grad_to_check.idx]
-                if next_id != 0:
-                    next_lib = self.grad_library.get(next_id)
-                    next_type = next_lib['type']
-
-                    if next_type == 't':
-                        first = 0
-                    elif next_type == 'g':
-                        first = next_lib['data'][4]
-                else:
-                    first = 0
-
-                # Check whether the difference between the first gradient value
-                # in the next block and the last value of the new gradient is
-                # achievable with the specified slew rate.
-                if abs(first - grad_to_check.stop[1]) > self.system.max_slew * self.system.grad_raster_time:
-                    raise RuntimeError(
-                        'Two consecutive gradients need to have the same amplitude at the connection point'
-                    )
-        elif abs(grad_to_check.start[1]) > self.system.max_slew * self.system.grad_raster_time:
-            raise RuntimeError('First gradient in the the first block has to start at 0.')
-
-        if (
-            grad_to_check.stop[1] > self.system.max_slew * self.system.grad_raster_time
-            and abs(grad_to_check.stop[0] - duration) > 1e-7
-        ):
-            raise RuntimeError("A gradient that doesn't end at zero needs to be aligned to the block boundary.")
+    grad_check(self, block_index, check_g, duration)
 
     self.block_events[block_index] = new_block
     self.block_durations[block_index] = float(duration)

--- a/src/pypulseq/Sequence/grad_check.py
+++ b/src/pypulseq/Sequence/grad_check.py
@@ -1,0 +1,174 @@
+from pypulseq import eps
+
+
+def grad_check(self, block_index, check_g, duration):
+    """
+    Check if connection to the previous block is correct.
+
+    Parameters
+    ----------
+    block_index : int
+        Current block index.
+    check_g : SimpleNamespace
+        Structure containing current gradient start and end (t, g) values for each
+        axis.
+    duration : float
+        Current block duration.
+
+    Raises
+    ------
+    RuntimeError
+        If either 1) initial block start with non-zero amplitude;
+        2) gradients starting with non-zero amplitude have a delay;
+        3) gradients starting with non-zero amplitude have different initial
+           amplitude value than the previous block at connecting point;
+        4) gradients ending with non-zero amplitude are not aligned with block raster;
+        4) gradients ending with non-zero amplitude are not aligned have different initial
+           amplitude value than the next block at connecting point.
+
+    """
+    max_slew_dt = self.system.max_slew * self.system.grad_raster_time
+
+    # If block has duration 0, nothing to do
+    if duration > 0:
+        for ax in range(3):
+            grad_to_check = check_g[ax]
+
+            # If gradient event starts with non-zero amplitude and 1) is in first block or 2) has a delay, error
+            # no need to compare against previous or following
+            if abs(grad_to_check.start[1]) > max_slew_dt:
+                if block_index == 1:
+                    raise RuntimeError('First gradient in the the first block has to start at 0.')
+                elif grad_to_check.start[0] > eps:
+                    raise RuntimeError('No delay allowed for gradients which start with a non-zero amplitude')
+
+            # If gradient event ends with non-zero amplitude and is not alined with block boundary, error
+            # no need to compare against previous or following
+            if abs(grad_to_check.stop[1]) > max_slew_dt and abs(grad_to_check.stop[0] - duration) > 1e-7:
+                raise RuntimeError('A gradient that does not end at zero needs to be aligned to the block boundary.')
+
+        # Now we know that gradient itself is ok. If this is the first block in the sequence
+        # it is over.
+        check_next = _get_neighboring_blocks(self, block_index)
+
+        # We now loop over axes and check connection point with previous
+        # and, if required, with next gradient
+        if self.next_free_block_ID > 1:
+            # TODO: add rotation of grad_check_data_prev / grad_check_data_next
+            # to logical axis according to current block rot_quaternion (v1.5.1)
+            for ax in range(3):
+                grad_to_check = check_g[ax]
+
+                # Check whether the difference between the last gradient value and
+                # the first value of the new gradient is achievable with the
+                # specified slew rate.
+                if abs(self.grad_check_data_prev.last_grad_vals[ax] - grad_to_check.start[1]) > max_slew_dt:
+                    raise RuntimeError(
+                        'Two consecutive gradients need to have the same amplitude at the connection point'
+                    )
+
+                # Check whether the difference between the first gradient value
+                # in the next block and the last value of the new gradient is
+                # achievable with the specified slew rate.
+                if (
+                    check_next
+                    and abs(self.grad_check_data_next.first_grad_vals[ax] - grad_to_check.stop[1]) > max_slew_dt
+                ):
+                    raise RuntimeError(
+                        'Two consecutive gradients need to have the same amplitude at the connection point'
+                    )
+
+                # TODO: add rotation to physical axis according to current block rot_quaternion
+                # before caching (v1.5.1)
+
+                # Now cache current block.
+                self.grad_check_data_prev.last_grad_vals[ax] = grad_to_check.stop[1]
+                self.grad_check_data_next.first_grad_vals[ax] = grad_to_check.start[1]
+        else:
+            # Just cache
+            for ax in range(3):
+                grad_to_check = check_g[ax]
+
+                # TODO: add rotation to physical axis according to current block rot_quaternion
+                # before caching (v1.5.1)
+
+                # Now cache current block.
+                self.grad_check_data_prev.last_grad_vals[ax] = grad_to_check.stop[1]
+                self.grad_check_data_next.first_grad_vals[ax] = grad_to_check.start[1]
+
+        self.grad_check_data_prev.valid_for_block_num = block_index
+        self.grad_check_data_next.valid_for_block_num = block_index - 1
+
+
+def _get_neighboring_blocks(self, block_index):
+    check_next = False
+    blocks = None
+    if self.next_free_block_ID > 1:
+        # First handle previous block.
+        # If cached block is already the one before the new one
+        # use it. Otherwise, read it.
+        if self.grad_check_data_prev.valid_for_block_num != block_index - 1:
+            # Initialize to empty / trapezoid gradient
+            self.grad_check_data_prev.valid_for_block_num = block_index - 1
+            self.grad_check_data_prev.last_grad_vals = [0.0, 0.0, 0.0]
+
+            # Get previous block ID
+            if block_index == self.next_free_block_ID:
+                # New block inserted
+                prev_block_index = next(reversed(self.block_events))
+            else:
+                blocks = list(self.block_events) if blocks is None else blocks
+                try:
+                    # Existing block overwritten
+                    idx = blocks.index(block_index)
+                    prev_block_index = blocks[idx - 1] if idx > 0 else None
+                except ValueError:
+                    # Inserting a new block with non-contiguous numbering
+                    prev_block_index = next(reversed(self.block_events))
+
+            # Fill previous block gradient data.
+            # If empty or trapezoid, implicitly leave it to 0
+            for ax in range(3):
+                if prev_block_index is not None:
+                    prev_id = self.block_events[prev_block_index][ax + 2]
+                    if prev_id != 0:
+                        prev_lib = self.grad_library.get(prev_id)
+                        prev_type = prev_lib['type']
+                        prev_dat = prev_lib['data']
+
+                        if prev_type == 'g':
+                            # TODO: change prev_dat[5] to prev_dat[2] in v1.5.x
+                            self.grad_check_data_prev.last_grad_vals[ax] = prev_dat[5]
+
+        # Now handle next block.
+        if block_index < self.next_free_block_ID and self.grad_check_data_next.valid_for_block_num != block_index + 1:
+            # Initialize to empty / trapezoid gradient
+            self.grad_check_data_next.valid_for_block_num = block_index + 1
+            self.grad_check_data_next.first_grad_vals = [0.0, 0.0, 0.0]
+
+            # Get next block ID
+            blocks = list(self.block_events) if blocks is None else blocks
+            try:
+                # Existing block overwritten
+                idx = blocks.index(block_index)
+                next_block_index = blocks[idx + 1] if idx < len(blocks) - 1 else None
+                check_next = True
+            except ValueError:
+                # Inserting a new block with non-contiguous numbering
+                next_block_index = None
+
+            # Fill next block gradient data.
+            # If empty or trapezoid, implicitly leave it to 0
+            for ax in range(3):
+                if next_block_index is not None:
+                    next_id = self.block_events[next_block_index][ax + 2]
+                    if next_id != 0:
+                        next_lib = self.grad_library.get(next_id)
+                        next_type = next_lib['type']
+                        next_dat = next_lib['data']
+
+                        if next_type == 'g':
+                            # TODO: change next_dat[4] to next_dat[1] in v1.5.x
+                            self.grad_check_data_next.first_grad_vals[ax] = next_dat[4]
+
+    return check_next

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -92,6 +92,8 @@ class Sequence:
         self.signature_type = ''
         self.signature_file = ''
         self.signature_value = ''
+        self.grad_check_data_prev = SimpleNamespace(valid_for_block_num=0, last_grad_vals=[0, 0, 0])
+        self.grad_check_data_next = SimpleNamespace(valid_for_block_num=0, first_grad_vals=[0, 0, 0])
 
         self.block_durations = {}
         self.extension_numeric_idx = []

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -173,4 +173,16 @@ def test_gradient_continuity_setblock7():
     assert list(seq.block_events.keys()) == [10, 5, 7]
 
 
+def test_gradient_continuity_setblock8():
+    # Add new gradient after valid override
+    seq = pp.Sequence()
+    seq.add_block(gx_endshigh)
+    seq.add_block(gx_allhigh)
+    seq.add_block(gx_startshigh)
+    seq.set_block(2, gx_allhigh)
+    seq.add_block(gx_endshigh)
+    seq.add_block(gx_allhigh)
+    seq.add_block(gx_startshigh)
+
+
 # TODO: Add other block functionality tests


### PR DESCRIPTION
Hi,
this PR refactors gradient continuity check to align closer to MATLAB.

Specifically, it adds a block caching mechanism which should speed-up continuity check when `add_block `is used. Contrary to MATLAB, it keeps check against next block.

When `set_block` is used to override an existing block or to add a non-contiguous block, it fall back to the previous approach where we search index of previous / last. 

This should also enable easier implementation of gradient check when rotation extension is enabled in v1.5.1+

Matteo