### PR TITLE
[towards v1.5.x] Fix missing first/last in make_arbitrary_grad

### DIFF
--- a/src/pypulseq/make_arbitrary_grad.py
+++ b/src/pypulseq/make_arbitrary_grad.py
@@ -131,6 +131,8 @@ def make_arbitrary_grad(
         grad.area = (waveform * system.grad_raster_time).sum()
         grad.tt = (np.arange(len(waveform)) + 0.5) * system.grad_raster_time
         grad.shape_dur = len(waveform) * system.grad_raster_time
+    grad.first = first
+    grad.last = last
 
     if trace_enabled():
         grad.trace = trace()


### PR DESCRIPTION
I realized there was a small bug in `make_arbitrary_grad`, where I forgot to assign `first` and `last` to the output `SimpleNamespace`. This PR fix this issue.