### PR TITLE
Fix test_report to work for sequences without gradients

### DIFF
--- a/src/pypulseq/Sequence/ext_test_report.py
+++ b/src/pypulseq/Sequence/ext_test_report.py
@@ -135,7 +135,7 @@ def ext_test_report(self) -> str:
         unique_k_positions = np.max(k_counters, axis=1) + 1
         is_cartesian = np.prod(unique_k_positions) == k_traj_rep1.shape[1]
     else:
-        unique_k_positions = 1
+        unique_k_positions = np.ones(1)
 
     gw_data = self.waveforms()
     gws = [np.zeros_like(x) for x in gw_data]
@@ -143,8 +143,15 @@ def ext_test_report(self) -> str:
     gs = np.zeros(len(gw_data))
 
     common_time = np.unique(np.concatenate(gw_data, axis=1)[0])
-    gw_ct = np.zeros((len(gw_data), len(common_time)))
-    gs_ct = np.zeros((len(gw_data), len(common_time) - 1))
+
+    # catch case where no gradients are present (e.g. FID)
+    if all(x.size == 0 for x in gw_data):
+        gw_ct = np.zeros(0)
+        gs_ct = np.zeros(0)
+    else:
+        gw_ct = np.zeros((len(gw_data), len(common_time)))
+        gs_ct = np.zeros((len(gw_data), len(common_time) - 1))
+
     for gc in range(len(gw_data)):
         if gw_data[gc].shape[1] > 0:
             # Slew


### PR DESCRIPTION
This should fix the issue that `test_report()` raises an error for sequences without gradients.
I tested it with a few FID sequences with global / selective RF pulses etc, but more tests are always welcome. 

Closes #309 