### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto-detect text files and normalize line endings to LF
+* text=auto
+
+# Force LF for python files
+*.py text eol=lf diff=python
+*.pyi text eol=lf diff=python
+
+# Force LF for Jupyter Notebooks
+*.ipynb text eol=lf
+
+# Force LF for markdown files
+*.md text eol=lf diff=markdown


### PR DESCRIPTION
As for example seen in #351, different line endings (CRLF vs. LF) lead to Git considering every line to be modified, resulting in a diff that shows way more than the actual code changes. 

Using the `.gitattributes` file added in this PR should force line ending to be LF in all python and markdown files and thus fix this issue in future PRs. 

The `diff=python` and `diff=markdown` should additionally improve the diff output. 