### PR TITLE
Test sequence runnable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@
 3. [⚡ Lightning-start - PyPulseq in your browser!][section-lightning-start]
 4. [🏃‍♂ Quickstart - example scripts][section-quickstart-examples]
 5. [🤿 Deep dive - custom pulse sequences][section-deep-dive]
-6. [👥 Contributing and Community guidelines][section-contributing]
-7. [📖 References][section-references]
+6. [🖵 Command-line utilities][section-cli]
+7. [👥 Contributing and Community guidelines][section-contributing]
+8. [📖 References][section-references]
 
 ---
 
@@ -135,14 +136,22 @@ Getting started with pulse sequence design using `PyPulseq` is simple:
 
 ---
 
-## 6. 👥 Contributing and Community guidelines
+## 6. 🖵 Command-line utilities
+
+* `ppseqtest` - A command-line utility to check a `.seq` file. It can print a test report, plot the sequence diagram, or plot the k-space.
+
+   Usage: `ppseqtest [--report] [--plot] [--k-space] <path_to_seq_file>`
+
+---
+
+## 7. 👥 Contributing and Community guidelines
 
 `PyPulseq` adheres to a code of conduct adapted from the [Contributor Covenant] code of conduct.
 Contributing guidelines can be found [here][contrib-guidelines].
 
 ---
 
-## 7. 📖 References
+## 8. 📖 References
 
 1. Ravi, Keerthi, Sairam Geethanath, and John Vaughan. "PyPulseq: A Python Package for MRI Pulse Sequence Design."
 Journal of Open Source Software 4.42 (2019): 1725.
@@ -159,9 +168,10 @@ resonance in medicine 77.4 (2017): 1544-1552.
 [contrib-guidelines]: https://github.com/imr-framework/pypulseq/blob/master/CONTRIBUTING.md
 [google-colab]: https://colab.research.google.com/
 [section-general-info]: #1-general-information
+[section-installation]: #2--installation
+[section-lightning-start]: #3--lightning-start---pypulseq-in-your-browser
+[section-quickstart-examples]: #4--example-scripts
+[section-deep-dive]: #5--deep-dive---custom-pulse-sequences
+[section-cli]: #6--command-line-utilities
 [section-contributing]: #7--contributing-and-community-guidelines
-[section-deep-dive]: #6--deep-dive---custom-pulse-sequences
-[section-installation]: #3--installation
-[section-lightning-start]: #4--lightning-start---pypulseq-in-your-browser
-[section-quickstart-examples]: #5--quickstart---example-scripts
 [section-references]: #8--references

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
   "scipy>=1.8.1",
 ]
 
+[project.scripts]
+ppseqtest = "pypulseq.scripts.test_sequence:main"
+
 [project.optional-dependencies]
 sigpy = ["sigpy>=0.1.26"]
 mplcursors = ["mplcursors"]

--- a/src/pypulseq/scripts/test_sequence.py
+++ b/src/pypulseq/scripts/test_sequence.py
@@ -1,7 +1,9 @@
 import argparse
+
 import matplotlib.pyplot as plt
 
 from pypulseq import Sequence
+
 
 def main():
     """
@@ -28,7 +30,7 @@ def main():
     args = argparser.parse_args()
 
     if not (args.k_space or args.plot or args.report):
-        print("No action specified. Use --k-space, --plot, or --report.")
+        print('No action specified. Use --k-space, --plot, or --report.')
         return
 
     seq = Sequence()
@@ -51,5 +53,6 @@ def main():
     if args.k_space or args.plot:
         plt.show()
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()

--- a/src/pypulseq/scripts/test_sequence.py
+++ b/src/pypulseq/scripts/test_sequence.py
@@ -41,7 +41,7 @@ def main():
         seq.plot(plot_now=False)
 
     if args.k_space:
-        k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc = seq.calculate_kspace()
+        k_traj_adc, k_traj, *_ = seq.calculate_kspace()
         plt.figure()
         plt.plot(k_traj[1], k_traj[2])
         plt.plot(k_traj_adc[1], k_traj_adc[2], '.', alpha=0.5)

--- a/src/pypulseq/scripts/test_sequence.py
+++ b/src/pypulseq/scripts/test_sequence.py
@@ -1,0 +1,55 @@
+import argparse
+import matplotlib.pyplot as plt
+
+from pypulseq import Sequence
+
+def main():
+    """
+    Test and visualize Pulseq sequence files.
+
+    This command-line tool reads a .seq file and provides options to:
+    - Display a test report of the sequence
+    - Plot sequence waveforms (RF, gradients, ADC)
+    - Visualize k-space trajectory
+
+    Command-line arguments:
+        seq_file: Path to the .seq file to analyze
+        --report, -r: Print a detailed test report
+        --plot, -p: Display sequence waveforms
+        --k-space, -k: Plot k-space trajectory with ADC sampling points
+
+    At least one action flag (--report, --plot, or --k-space) must be specified.
+    """
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('seq_file', type=str, help='Path to .seq file')
+    argparser.add_argument('--k-space', '-k', action='store_true', help='Plot k-space trajectory')
+    argparser.add_argument('--plot', '-p', action='store_true', help='Plot sequence waveforms')
+    argparser.add_argument('--report', '-r', action='store_true', help='Print test report')
+    args = argparser.parse_args()
+
+    if not (args.k_space or args.plot or args.report):
+        print("No action specified. Use --k-space, --plot, or --report.")
+        return
+
+    seq = Sequence()
+    seq.read(args.seq_file)
+
+    if args.report:
+        print(seq.test_report())
+
+    if args.plot:
+        seq.plot(plot_now=False)
+
+    if args.k_space:
+        k_traj_adc, k_traj, t_excitation, t_refocusing, t_adc = seq.calculate_kspace()
+        plt.figure()
+        plt.plot(k_traj[1], k_traj[2])
+        plt.plot(k_traj_adc[1], k_traj_adc[2], '.', alpha=0.5)
+        ax = plt.gca()
+        ax.set_aspect('equal')
+
+    if args.k_space or args.plot:
+        plt.show()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a runnable script "ppseqtest" that can be used to plot an existing .seq file. It is useful to visualize a third-party file, or generated with another framework.

A section "command-line utilities" was added to the README

Minor change:
- Links in the README were fixed and reorganized.