### PR TITLE
Add rf_plot modes (auto/abs/real/imag) to sequence plotting

### DIFF
--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -2,7 +2,7 @@ import math
 from collections import OrderedDict
 from copy import deepcopy
 from types import SimpleNamespace
-from typing import Any, List, Tuple, Union, Literal
+from typing import Any, List, Literal, Tuple, Union
 from warnings import warn
 
 try:

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -1057,6 +1057,7 @@ class Sequence:
         overlay: SeqPlot = None,
         stacked: bool = False,
         show_guides: bool = False,
+        rf_plot: str = 'auto',
     ) -> SeqPlot:
         """
         Plot `Sequence`.
@@ -1090,6 +1091,11 @@ class Sequence:
             If False, use separate figures for RF/ADC and gradients.
         show_guides : bool, default=False
             If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
+        rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
+            Determines how to plot RF waveforms in the RF magnitude plot.
+            If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
+            If 'abs', plots magnitude for all RF events.
+            If 'real' or 'imag', plots the respective component for all RF events.
 
         Returns
         -------
@@ -1109,6 +1115,7 @@ class Sequence:
             overlay,
             stacked,
             show_guides,
+            rf_plot=rf_plot,
         )
 
     def read(self, file_path: str, detect_rf_use: bool = False, remove_duplicates: bool = True) -> None:

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -2,7 +2,7 @@ import math
 from collections import OrderedDict
 from copy import deepcopy
 from types import SimpleNamespace
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Tuple, Union, Literal
 from warnings import warn
 
 try:
@@ -1016,7 +1016,7 @@ class Sequence:
         gx_color: str = 'blue',
         gy_color: str = 'red',
         gz_color: Tuple[float] = (0, 0.5, 0.3),
-        rf_plot: str = 'abs',
+        rf_plot: Literal['abs', 'real', 'imag'] = 'abs',
     ):
         """
         Plot sequence using paper-style formatting (minimalist, high-contrast layout).
@@ -1038,8 +1038,11 @@ class Sequence:
             Color for gradient Y waveform.
         gz_color : color, default=(0, 0.5, 0.3)
             Color for gradient Z waveform.
-        rf_plot : {'abs', 'real', 'imag'}, default='abs'
-            Determines how to plot RF waveforms (magnitude, real or imaginary part).
+        rf_plot : str, default='abs'
+            Determines how to plot RF waveforms in the RF magnitude plot.
+            Must be one of 'auto', 'abs', 'real' or 'imag'.
+            If 'abs', plots magnitude for all RF events.
+            If 'real' or 'imag', plots the respective component for all RF events.
 
         """
         ext_paper_plot(self, time_range, line_width, axes_color, rf_color, gx_color, gy_color, gz_color, rf_plot)
@@ -1057,7 +1060,7 @@ class Sequence:
         overlay: SeqPlot = None,
         stacked: bool = False,
         show_guides: bool = False,
-        rf_plot: str = 'auto',
+        rf_plot: Literal['auto', 'abs', 'real', 'imag'] = 'auto',
     ) -> SeqPlot:
         """
         Plot `Sequence`.
@@ -1091,8 +1094,9 @@ class Sequence:
             If False, use separate figures for RF/ADC and gradients.
         show_guides : bool, default=False
             If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
-        rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
+        rf_plot : str, default='auto'
             Determines how to plot RF waveforms in the RF magnitude plot.
+            Must be one of 'auto', 'abs', 'real' or 'imag'.
             If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
             If 'abs', plots magnitude for all RF events.
             If 'real' or 'imag', plots the respective component for all RF events.

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -1038,9 +1038,8 @@ class Sequence:
             Color for gradient Y waveform.
         gz_color : color, default=(0, 0.5, 0.3)
             Color for gradient Z waveform.
-        rf_plot : str, default='abs'
-            Determines how to plot RF waveforms in the RF magnitude plot.
-            Must be one of 'auto', 'abs', 'real' or 'imag'.
+        rf_plot : {'abs', 'real', 'imag'}, default='abs'
+            Determines how to plot the RF waveforms.
             If 'abs', plots magnitude for all RF events.
             If 'real' or 'imag', plots the respective component for all RF events.
 
@@ -1094,9 +1093,8 @@ class Sequence:
             If False, use separate figures for RF/ADC and gradients.
         show_guides : bool, default=False
             If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
-        rf_plot : str, default='auto'
-            Determines how to plot RF waveforms in the RF magnitude plot.
-            Must be one of 'auto', 'abs', 'real' or 'imag'.
+        rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
+            Determines how to plot the RF waveforms.
             If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
             If 'abs', plots magnitude for all RF events.
             If 'real' or 'imag', plots the respective component for all RF events.
@@ -1128,9 +1126,10 @@ class Sequence:
 
         Parameters
         ----------
-        detect_rf_use
         file_path : str
             Path to `.seq` file to be read.
+        detect_rf_use : bool, default=False
+            If True, try to infer intended use of the RF pulses if `use` attributes are not set.
         remove_duplicates : bool, default=True
             Remove duplicate events from the sequence after reading.
         """

--- a/src/pypulseq/utils/paper_plot.py
+++ b/src/pypulseq/utils/paper_plot.py
@@ -39,9 +39,8 @@ def paper_plot(
         Color for gradient Y waveform.
     gz_color : color, default=(0, 0.5, 0.3)
         Color for gradient Z waveform.
-    rf_plot : str, default='abs'
-        Determines how to plot RF waveforms in the RF magnitude plot.
-        Must be one of 'abs', 'real' or 'imag'.
+    rf_plot : {'abs', 'real', 'imag'}, default='abs'
+        Determines how to plot the RF waveforms.
         If 'abs', plots magnitude for all RF events.
         If 'real' or 'imag', plots the respective component for all RF events.
 

--- a/src/pypulseq/utils/paper_plot.py
+++ b/src/pypulseq/utils/paper_plot.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Literal, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +15,7 @@ def paper_plot(
     gx_color: str = 'blue',
     gy_color: str = 'red',
     gz_color: Tuple[float] = (0, 0.5, 0.3),
-    rf_plot: str = 'abs',
+    rf_plot: Literal['abs', 'real', 'imag'] = 'abs',
 ):
     """
     Plot sequence using paper-style formatting (minimalist, high-contrast layout).
@@ -39,8 +39,11 @@ def paper_plot(
         Color for gradient Y waveform.
     gz_color : color, default=(0, 0.5, 0.3)
         Color for gradient Z waveform.
-    rf_plot : {'abs', 'real', 'imag'}, default='abs'
-        Determines how to plot RF waveforms (magnitude, real or imaginary part).
+    rf_plot : str, default='abs'
+        Determines how to plot RF waveforms in the RF magnitude plot.
+        Must be one of 'abs', 'real' or 'imag'.
+        If 'abs', plots magnitude for all RF events.
+        If 'real' or 'imag', plots the respective component for all RF events.
 
     """
     # Get waveform data

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -628,9 +628,7 @@ def _seq_plot(
 
                     # Plot angle of complex signal
                     phase_corrected = (
-                        signal
-                        * np.exp(1j * full_phase_offset)
-                        * np.exp(1j * 2 * math.pi * time * full_freq_offset)
+                        signal * np.exp(1j * full_phase_offset) * np.exp(1j * 2 * math.pi * time * full_freq_offset)
                     )
                     sc_corrected = (
                         signal[index_center]

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -61,9 +61,8 @@ class SeqPlot:
         If False, use separate figures for RF/ADC and gradients.
     show_guides : bool, default=False
         If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
-    rf_plot : str, default='auto'
-        Determines how to plot RF waveforms in the RF magnitude plot.
-        Must be one of 'auto', 'abs', 'real' or 'imag'.
+    rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
+        Determines how to plot the RF waveforms.
         If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
         If 'abs', plots magnitude for all RF events.
         If 'real' or 'imag', plots the respective component for all RF events.

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import numpy as np
 from matplotlib import pyplot as plt
 
+from pypulseq import eps
 from pypulseq.calc_rf_center import calc_rf_center
 from pypulseq.Sequence import parula
 from pypulseq.supported_labels_rf_use import get_supported_labels
@@ -59,6 +60,11 @@ class SeqPlot:
         If False, use separate figures for RF/ADC and gradients.
     show_guides : bool, default=False
         If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
+    rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
+            Determines how to plot RF waveforms in the RF magnitude plot.
+            If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
+            If 'abs', plots magnitude for all RF events.
+            If 'real' or 'imag', plots the respective component for all RF events.
 
     Attributes
     ----------
@@ -87,6 +93,7 @@ class SeqPlot:
         overlay: 'SeqPlot' = None,
         stacked: bool = False,
         show_guides: bool = False,
+        rf_plot: str = 'auto',
     ):
         # Handle optional dependencies
         if _MPLCURSORS_AVAILABLE is False:
@@ -143,6 +150,7 @@ class SeqPlot:
                 fig1=fig1,
                 fig2=fig2,
                 stacked=stacked,
+                rf_plot=rf_plot,
             )
         finally:
             # restore interactive state if we changed it
@@ -339,6 +347,7 @@ def _seq_plot(
     fig1,
     fig2,
     stacked,
+    rf_plot,
 ):
     mpl.rcParams['lines.linewidth'] = 0.75  # Set default Matplotlib linewidth
 
@@ -349,9 +358,10 @@ def _seq_plot(
         raise ValueError('Invalid time range')
     if time_disp not in valid_time_units:
         raise ValueError('Unsupported time unit')
-
     if grad_disp not in valid_grad_units:
         raise ValueError('Unsupported gradient unit. Supported gradient units are: ' + str(valid_grad_units))
+    if rf_plot not in ['auto', 'abs', 'real', 'imag']:
+        raise ValueError('Unsupported RF plot type. Supported types are: ' + str(['auto', 'abs', 'real', 'imag']))
 
     # If figs were provided but closed (None), create new ones
     if stacked:
@@ -541,7 +551,8 @@ def _seq_plot(
                     signal = np.concatenate((signal, [0]))
                     time = np.concatenate((time, [time[-1]]))
 
-                signal_is_real = max(np.abs(np.imag(signal))) / max(np.abs(np.real(signal))) < 1e-6
+                signal_is_real = max(np.abs(np.imag(signal))) / (max(np.abs(np.real(signal))) + eps) < 1e-6
+                signal_is_imag = max(np.abs(np.real(signal))) / (max(np.abs(np.imag(signal))) + eps) < 1e-6
 
                 full_freq_offset = rf.freq_offset + rf.freq_ppm * 1e-6 * seq.system.B0
                 full_phase_offset = rf.phase_offset + rf.phase_ppm * 1e-6 * seq.system.B0
@@ -563,7 +574,7 @@ def _seq_plot(
                 time_center_with_delay = t_factor * (t0 + time_center + rf.delay)
 
                 # Choose plot behavior based on realness of signal
-                if signal_is_real:
+                if rf_plot == 'real' or (rf_plot == 'auto' and signal_is_real):
                     # Plot real part of signal
                     sp12.plot(time_with_delay, np.real(signal))
 
@@ -587,13 +598,39 @@ def _seq_plot(
                         np.angle(sc_corrected),
                         'xb',
                     )
-                else:
+                elif rf_plot == 'imag' or (rf_plot == 'auto' and signal_is_imag):
+                    # Plot imaginary part of signal
+                    sp12.plot(time_with_delay, np.imag(signal))
+
+                    # Include sign(imag(signal)) factor like MATLAB
+                    phase_corrected = (
+                        signal
+                        * np.sign(np.imag(signal))
+                        * np.exp(1j * full_phase_offset)
+                        * np.exp(1j * 2 * math.pi * time * full_freq_offset)
+                    )
+                    sc_corrected = (
+                        signal[index_center]
+                        * np.exp(1j * full_phase_offset)
+                        * np.exp(1j * 2 * math.pi * time[index_center] * full_freq_offset)
+                    )
+
+                    sp13.plot(
+                        time_with_delay,
+                        np.angle(phase_corrected),
+                        time_center_with_delay,
+                        np.angle(sc_corrected),
+                        'xb',
+                    )
+                elif rf_plot == 'abs' or (rf_plot == 'auto' and not signal_is_real and not signal_is_imag):
                     # Plot magnitude of complex signal
                     sp12.plot(time_with_delay, np.abs(signal))
 
                     # Plot angle of complex signal
                     phase_corrected = (
-                        signal * np.exp(1j * full_phase_offset) * np.exp(1j * 2 * math.pi * time * full_freq_offset)
+                        signal
+                        * np.exp(1j * full_phase_offset)
+                        * np.exp(1j * 2 * math.pi * time * full_freq_offset)
                     )
                     sc_corrected = (
                         signal[index_center]

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -4,6 +4,7 @@ import contextlib
 import itertools
 import math
 import typing
+from typing import Literal
 
 import matplotlib as mpl
 import numpy as np
@@ -60,11 +61,12 @@ class SeqPlot:
         If False, use separate figures for RF/ADC and gradients.
     show_guides : bool, default=False
         If True, enable dynamic vertical hairline guides that follow the cursor. Requires `mplcursors`.
-    rf_plot : {'auto', 'abs', 'real', 'imag'}, default='auto'
-            Determines how to plot RF waveforms in the RF magnitude plot.
-            If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
-            If 'abs', plots magnitude for all RF events.
-            If 'real' or 'imag', plots the respective component for all RF events.
+    rf_plot : str, default='auto'
+        Determines how to plot RF waveforms in the RF magnitude plot.
+        Must be one of 'auto', 'abs', 'real' or 'imag'.
+        If 'auto', plots magnitude for all RF events except those that are purely real or imaginary, which are plotted as such.
+        If 'abs', plots magnitude for all RF events.
+        If 'real' or 'imag', plots the respective component for all RF events.
 
     Attributes
     ----------
@@ -93,7 +95,7 @@ class SeqPlot:
         overlay: 'SeqPlot' = None,
         stacked: bool = False,
         show_guides: bool = False,
-        rf_plot: str = 'auto',
+        rf_plot: Literal['auto', 'abs', 'real', 'imag'] = 'auto',
     ):
         # Handle optional dependencies
         if _MPLCURSORS_AVAILABLE is False:
@@ -699,7 +701,14 @@ def _seq_plot(
 
     # Set axis labels
     sp11.set_ylabel('ADC')
-    sp12.set_ylabel('RF mag (Hz)')
+    if rf_plot == 'auto':
+        sp12.set_ylabel('RF auto: mag/real/imag (Hz)')
+    elif rf_plot == 'abs':
+        sp12.set_ylabel('RF mag (Hz)')
+    elif rf_plot == 'real':
+        sp12.set_ylabel('RF real (Hz)')
+    elif rf_plot == 'imag':
+        sp12.set_ylabel('RF imag (Hz)')
     sp13.set_ylabel('RF/ADC phase (rad)')
     sp13.set_xlabel(f't ({time_disp})')
     sp21.set_ylabel(f'Gx ({grad_disp})')

--- a/tests/test_sequence_plot.py
+++ b/tests/test_sequence_plot.py
@@ -1,8 +1,8 @@
 """Simple unit tests for Sequence.plot() method."""
-
 import math
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pypulseq as pp
 
 
@@ -109,9 +109,10 @@ def test_plot_rf_plot_auto_default():
     result_default = seq1.plot(plot_now=False)
     result_auto = seq2.plot(plot_now=False, rf_plot='auto')
 
-    # Both should succeed and produce figures
-    assert result_default.fig1 is not None
-    assert result_auto.fig1 is not None
+    # Compare y-data of all lines in fig1 (RF/ADC) - should be identical
+    for ax1, ax2 in zip(result_default.fig1.get_axes(), result_auto.fig1.get_axes()):
+        for line1, line2 in zip(ax1.get_lines(), ax2.get_lines()):
+            np.testing.assert_array_equal(line1.get_ydata(), line2.get_ydata())
 
     plt.close('all')
 

--- a/tests/test_sequence_plot.py
+++ b/tests/test_sequence_plot.py
@@ -1,4 +1,5 @@
 """Simple unit tests for Sequence.plot() method."""
+
 import math
 
 import matplotlib.pyplot as plt

--- a/tests/test_sequence_plot.py
+++ b/tests/test_sequence_plot.py
@@ -72,3 +72,62 @@ def test_plot_stacked_behavior():
     assert len(result.ax1) == 6  # 3 for RF/ADC + 3 for Gradients
 
     plt.close('all')
+
+
+def test_plot_rf_plot_modes():
+    """Test rf_plot parameter with different modes."""
+    plt.close('all')
+    seq = create_test_sequence()
+
+    # Test all valid modes without raising
+    for mode in ['auto', 'abs', 'real', 'imag']:
+        result = seq.plot(plot_now=False, rf_plot=mode)
+        assert result.fig1 is not None, f"Failed for rf_plot='{mode}'"
+        plt.close('all')
+
+
+def test_plot_rf_plot_invalid_mode():
+    """Test that invalid rf_plot mode raises ValueError."""
+    plt.close('all')
+    seq = create_test_sequence()
+
+    try:
+        seq.plot(plot_now=False, rf_plot='invalid')
+        raise AssertionError('Should have raised ValueError for invalid rf_plot mode')
+    except ValueError as e:
+        assert 'Unsupported RF plot type' in str(e)
+
+    plt.close('all')
+
+
+def test_plot_rf_plot_auto_default():
+    """Test that rf_plot='auto' is the default and produces same result as no argument."""
+    plt.close('all')
+    seq1 = create_test_sequence()
+    seq2 = create_test_sequence()
+
+    result_default = seq1.plot(plot_now=False)
+    result_auto = seq2.plot(plot_now=False, rf_plot='auto')
+
+    # Both should succeed and produce figures
+    assert result_default.fig1 is not None
+    assert result_auto.fig1 is not None
+
+    plt.close('all')
+
+
+def test_plot_rf_plot_with_overlay():
+    """Test that rf_plot parameter works correctly with overlay."""
+    plt.close('all')
+    seq = create_test_sequence()
+
+    # First plot with rf_plot='real'
+    sp1 = seq.plot(plot_now=False, rf_plot='real')
+
+    # Overlay with rf_plot='abs'
+    sp2 = seq.plot(overlay=sp1, plot_now=False, rf_plot='abs')
+
+    # Should reuse figures from overlay
+    assert id(sp2.fig1) == id(sp1.fig1)
+
+    plt.close('all')


### PR DESCRIPTION
Users can now choose rf_plot = 'auto', 'abs', 'real', 'imag' (default = 'auto' preserves existing behaviour).

If seq.plot(rf_plot = 'auto'), the RF magnitude is plotted in the RF magnitude subplot, unless RF pulses are purely real or imaginary, in which case the real or imaginary part is plotted and the phase waveform is adjusted accordingly.
If seq.plot(rf_plot = 'abs'), the RF magnitude is always plotted.
If seq.plot(rf_plot = 'real') or seq.plot(rf_plot = 'imag'), the real or imaginary parts are plotted.

Additional tests have been added to tests/test_sequence_plot.py to test this new functionality.