### PR TITLE
Fix `ext_test_report` reporting incorrect echo time when noise prescans are present

### DIFF
--- a/src/pypulseq/Sequence/ext_test_report.py
+++ b/src/pypulseq/Sequence/ext_test_report.py
@@ -49,6 +49,7 @@ def ext_test_report_data(self) -> Dict[str, Any]:
     t_excitation = np.asarray(t_excitation)
 
     # remove all ADC events that come before the first RF event (noise scans or alike)
+    k_traj_adc = k_traj_adc[:, t_adc > t_excitation[0]]
     t_adc = t_adc[t_adc > t_excitation[0]]
 
     k_abs_adc = np.sqrt(np.sum(np.square(k_traj_adc), axis=0))


### PR DESCRIPTION
The function [`ext_test_report`](https://github.com/imr-framework/pypulseq/blob/530c9daff6444689be89128459235fa94708d618/src/pypulseq/Sequence/ext_test_report.py) can give incorrect echo times if there are noise ADCs before the main acquisition. This can be demonstrated using the example code below, where the echo time of the main acquisition is 4 ms, but `ext_test_report` incorrectly reports it as 2.413 ms.

The issue arises because while the array `t_adc`  is truncated to remove ADCs before any excitation pulses, this truncation is not performed on the array containing the k-space samples at the time points in `t_adc`. This pull request fixes this issue, giving the correct echo time of 4 ms.

## Example code demonstrating the error
```python
import numpy as np

import pypulseq as pp

# Sequence parameters
fov_x = 128e-3
n_x = 128
n_noise = 1
n_repetition = 2
te = 4e-3
tr = 8e-3

# Set up sequence
system = pp.Opts()
seq = pp.Sequence(system)

# Create slice selection pulse and gradient
rf = pp.make_block_pulse(
    flip_angle=np.deg2rad(8),
    duration=1e-3,
    system=system,
    delay=system.rf_dead_time,
    use='excitation'
)
rf_duration = pp.calc_duration(rf)
rf_centre_time = pp.calc_rf_center(rf)[0]+rf.delay

# Define gradients and ADC events.
gx = pp.make_trapezoid(channel='x', flat_area=n_x/fov_x, flat_time=3.2e-3, system=system)
gx_duration = pp.calc_duration(gx)
adc = pp.make_adc(num_samples=n_x, duration=gx.flat_time, delay=gx.rise_time, system=system)
gx_pre = pp.make_trapezoid(channel='x', area=-gx.area/2, system=system)
gx_pre_duration = pp.calc_duration(gx_pre)

# Noise acquisitions
seq.add_block(pp.make_label('NOISE', 'SET', 1))
for i_noise in range(n_noise):
    seq.add_block(adc)
seq.add_block(pp.make_label('NOISE', 'SET', 0))

# Main acquisitions
te_delay = te - gx_duration/2 - (rf_duration - rf_centre_time)
te_delay = np.ceil(te_delay / seq.grad_raster_time) * seq.grad_raster_time
tr_delay = tr - rf_centre_time - (te - gx_duration/2)
tr_delay = np.ceil(tr_delay / seq.grad_raster_time) * seq.grad_raster_time
for i_repetition in range(n_repetition):
    seq.add_block(rf)
    seq.add_block(gx_pre, pp.make_delay(te_delay))
    seq.add_block(gx, adc, pp.make_delay(tr_delay))
    seq.add_block(pp.make_label('REP', 'INC', 1))

# Should report TE: 0.004000 s, but actually reports TE: 0.002413 s
print(seq.test_report())
```