### PR TITLE
Fix publish-to-pypi config / workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,9 +3,8 @@ name: Publish to PyPI
 on: 
   push:
     tags:
-      tags:
-        - 'v*'
-        - '[0-9]*'
+      - 'v*'
+      - '[0-9]*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The 2nd nested tags mapping was probably unintentional and leads to failing workflows... 
I think I introduced it myself in #355 