### PR TITLE
Bug fix related to phase_offset and phase_ppm units

### DIFF
--- a/src/pypulseq/Sequence/calc_grad_spectrum.py
+++ b/src/pypulseq/Sequence/calc_grad_spectrum.py
@@ -29,15 +29,15 @@ def calculate_gradient_spectrum(
     Parameters
     ----------
     max_frequency : float, optional
-        Maximum frequency to include in spectrograms. The default is 2000.
+        Maximum frequency in hertz (Hz) to include in spectrograms. The default is 2000.
     window_width : float, optional
-        Window width (in seconds). The default is 0.05.
+        Window width in seconds (s). The default is 0.05.
     frequency_oversampling : float, optional
         Oversampling in the frequency dimension, higher values make
         smoother spectrograms. The default is 3.
     time_range : List[float], optional
-        Time range over which to calculate the spectrograms as a list of
-        two timepoints (in seconds) (e.g. [1, 1.5])
+        Time range in seconds (s) over which to calculate the spectrograms as a list of
+        two timepoints (e.g. [1, 1.5])
         The default is None.
     plot : bool, optional
         Whether to plot the spectograms. The default is True.

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -1349,7 +1349,7 @@ class Sequence:
 
                 full_freq_offset = rf.freq_offset + rf.freq_ppm * 1e-6 * self.system.gamma * self.system.B0
                 full_phase_offset = rf.phase_offset + rf.phase_ppm * 1e-6 * self.system.gamma * self.system.B0
-                full_phase_offset = full_phase_offset + 2 * math.pi * full_freq_offset * tc
+                full_phase_offset += 2 * math.pi * full_freq_offset * tc
 
                 if not hasattr(rf, 'use') or block.rf.use in [
                     'excitation',

--- a/src/pypulseq/add_gradients.py
+++ b/src/pypulseq/add_gradients.py
@@ -31,9 +31,9 @@ def add_gradients(
     system : Opts, default=Opts()
         System limits.
     max_grad : float, default=0
-        Maximum gradient amplitude.
+        Maximum gradient amplitude (Hz/m).
     max_slew : float, default=0
-        Maximum slew rate.
+        Maximum slew rate (Hz/m/s).
 
     Returns
     -------

--- a/src/pypulseq/add_ramps.py
+++ b/src/pypulseq/add_ramps.py
@@ -30,9 +30,9 @@ def add_ramps(
     rf : SimpleNamespace, default=None
         Add a segment of zeros over the ramp times to an RF shape.
     max_grad : int, default=0
-        Maximum gradient amplitude.
+        Maximum gradient amplitude (Hz/m).
     max_slew : int, default=0
-        Maximum slew rate.
+        Maximum slew rate (Hz/m/s).
     oversampling : bool, default=False
         Boolean flag to indicate if gradient is oversampled by a factor of 2.
 

--- a/src/pypulseq/calc_ramp.py
+++ b/src/pypulseq/calc_ramp.py
@@ -28,11 +28,11 @@ def calc_ramp(
     k_end : numpy.ndarray
         Two following points in k-space. Shape is `[3, 2]`. From these points, the target gradient will be calculated.
     max_grad : float or array_like, default=0
-        Maximum total gradient strength. Either a single value or one value for each coordinate, of shape `[3, 1]`.
+        Maximum total gradient strength (Hz/m). Either a single value or one value for each coordinate, of shape `[3, 1]`.
     max_points : int, default=500
         Maximum number of k-space points to be used in connecting `k0` and `k_end`.
     max_slew : float or array_like, default=0
-        Maximum total slew rate. Either a single value or one value for each coordinate, of shape `[3, 1]`.
+        Maximum total slew rate (Hz/m/s). Either a single value or one value for each coordinate, of shape `[3, 1]`.
     system : Opts, default=Opts()
         System limits.
     oversampling : bool, default=False

--- a/src/pypulseq/make_adc.py
+++ b/src/pypulseq/make_adc.py
@@ -38,13 +38,13 @@ def make_adc(
     delay : float, default=0
         Delay in seconds (s) of ADC readout event.
     freq_offset : float, default=0
-        Frequency offset of ADC readout event.
+        Frequency offset in hertz (Hz) of ADC readout event.
     phase_offset : float, default=0
-        Phase offset of ADC readout event.
+        Phase offset in radians (rad) of ADC readout event.
     freq_ppm : float, default=0
-        PPM frequency offset of ADC readout event.
+        PPM frequency offset in parts per million (ppm) of ADC readout event.
     phase_ppm : float, default=0
-        PPM phase offset of ADC readout event.
+        PPM phase offset in radians per megahertz (rad/MHz) of ADC readout event.
     phase_modulation : Union[np.ndarray, None], default=None
         Phase modulation array for FOV shifting.
         If provided, it must have `num_samples` number of samples.

--- a/src/pypulseq/make_adiabatic_pulse.py
+++ b/src/pypulseq/make_adiabatic_pulse.py
@@ -91,28 +91,32 @@ def make_adiabatic_pulse(
         One of 'hypsec' or 'wurst' pulse types.
     adiabaticity : int, default=4
     bandwidth : int, default=40000
-        Pulse bandwidth.
+        Pulse bandwidth in hertz (Hz).
     beta : float, default=800.0
-        AM waveform parameter.
+        AM waveform parameter in radians per second (rad/s).
     delay : float, default=0
         Delay in seconds (s).
     duration : float, default=10e-3
-        Pulse time (s).
+        Pulse duration in seconds (s).
     dwell : float, default=None
+        Temporal sampling step of waveform in seconds (s). If set to None, will use `system.rf_raster_time`.
     freq_offset : float, default=0
+        Frequency offset in hertz (Hz).
     max_grad : float, default=None
-        Maximum gradient strength.
+        Maximum gradient strength (Hz/m).
     max_slew : float, default=None
-        Maximum slew rate.
+        Maximum slew rate (Hz/m/s).
     mu : float, default=4.9
         Constant determining amplitude of frequency sweep.
     n_fac : int, default=40
         Power to exponentiate to within AM term. ~20 or greater is typical.
     phase_offset : float, default=0
-        Phase offset.
+        Phase offset in radians (rad).
     return_gz : bool, default=False
         Boolean flag to indicate if the slice-selective gradient has to be returned.
     slice_thickness : float, default=0
+        Slice thickness in meters (m) of accompanying slice select trapezoidal event.
+        The slice thickness determines the area of the slice select event.
     system : Opts, default=Opts()
         System limits.
     use : str, default='inversion'
@@ -120,9 +124,9 @@ def make_adiabatic_pulse(
         Must be one of 'excitation', 'refocusing', 'inversion',
         'saturation', 'preparation', 'other', 'undefined'.
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
 
     Returns
     -------

--- a/src/pypulseq/make_arbitrary_grad.py
+++ b/src/pypulseq/make_arbitrary_grad.py
@@ -45,10 +45,10 @@ def make_arbitrary_grad(
         System limits.
         Will default to `pypulseq.opts.default` if not provided.
     max_grad : float
-        Maximum gradient strength.
+        Maximum gradient strength (Hz/m).
         Will default to `system.max_grad` if not provided.
     max_slew : float
-        Maximum slew rate.
+        Maximum slew rate (Hz/m/s).
         Will default to `system.max_slew` if not provided.
     delay : float, default=0
         Delay in seconds (s).

--- a/src/pypulseq/make_arbitrary_rf.py
+++ b/src/pypulseq/make_arbitrary_rf.py
@@ -41,28 +41,28 @@ def make_arbitrary_rf(
     signal : numpy.ndarray
         Arbitrary waveform.
     flip_angle : float
-        Flip angle in radians.
+        Flip angle in radians (rad).
     bandwidth : float, default=0
-        Bandwidth in Hertz (Hz).
+        Bandwidth in hertz (Hz).
     delay : float, default=0
         Delay in seconds (s) of accompanying slice select trapezoidal event.
     dwell : float, default=0
-        Temporal sampling step of waveform. If set to 0, will use `system.rf_raster_time`.
+        Temporal sampling step of waveform in seconds (s). If set to 0, will use `system.rf_raster_time`.
     freq_offset : float, default=0
-        Frequency offset in Hertz (Hz).
+        Frequency offset in hertz (Hz).
     no_signal_scaling : bool, default=False
         If set to True no rescaling of the RF amplitude will happen. E.g. for adiabatic pulses.
     max_grad : float, default=system.max_grad
-        Maximum gradient strength of accompanying slice select trapezoidal event.
+        Maximum gradient strength (Hz/m) of accompanying slice select trapezoidal event .
     max_slew : float, default=system.max_slew
-        Maximum slew rate of accompanying slice select trapezoidal event.
+        Maximum slew rate (Hz/m/s) of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
-        Phase offset in Hertz (Hz).a
+        Phase offset in radians (rad).
     return_gz : bool, default=False
         Boolean flag to indicate if slice-selective gradient has to be returned.
     slice_thickness : float, default=0
-        Slice thickness (m) of accompanying slice select trapezoidal event. The slice thickness determines the area of the
-        slice select event.
+        Slice thickness (m) of accompanying slice select trapezoidal event.
+        The slice thickness determines the area of the slice select event.
     system : Opts, default=Opts()
         System limits.
     time_bw_product : float, default=0
@@ -72,11 +72,11 @@ def make_arbitrary_rf(
         Must be one of 'excitation', 'refocusing', 'inversion',
         'saturation', 'preparation', 'other', 'undefined'.
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
     center : float, default=None
-        RF center (s).
+        RF center in seconds (s).
 
     Returns
     -------

--- a/src/pypulseq/make_block_pulse.py
+++ b/src/pypulseq/make_block_pulse.py
@@ -31,21 +31,21 @@ def make_block_pulse(
     Parameters
     ----------
     flip_angle : float
-        Flip angle in radians.
+        Flip angle in radians (rad).
     delay : float, default=0
         Delay in seconds (s).
     duration : float, default=None
         Duration in seconds (s).
     bandwidth : float, default=None
-        Bandwidth in Hertz (Hz).
+        Bandwidth in hertz (Hz).
         If supplied without time_bw_product duration = 1 / (4 * bandwidth)
     time_bw_product : float, default=None
         Time-bandwidth product.
         If supplied with bandwidth, duration = time_bw_product / bandwidth
     freq_offset : float, default=0
-        Frequency offset in Hertz (Hz).
+        Frequency offset in hertz (Hz).
     phase_offset : float, default=0
-        Phase offset Hertz (Hz).
+        Phase offset in radians (rad).
     system : Opts, default=Opts()
         System limits.
     use : str, default='undefined'
@@ -53,9 +53,9 @@ def make_block_pulse(
         Must be one of 'excitation', 'refocusing', 'inversion',
         'saturation', 'preparation', 'other', 'undefined'.
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
 
     Returns
     -------

--- a/src/pypulseq/make_extended_trapezoid.py
+++ b/src/pypulseq/make_extended_trapezoid.py
@@ -37,17 +37,17 @@ def make_extended_trapezoid(
     convert_to_arbitrary : bool, default=False
         Boolean flag to indicate if the extended trapezoid gradient has to be converted into an arbitrary gradient.
     amplitudes : numpy.ndarray, default=09
-        Values defined at `times` time indices.
+        Gradient values (Hz/m) defined at `times` time indices.
     max_grad : float, default=0
-        Maximum gradient strength.
+        Maximum gradient strength (Hz/m).
     max_slew : float, default=0
-        Maximum slew rate.
+        Maximum slew rate (Hz/m/s).
     system : Opts, default=Opts()
         System limits.
     skip_check : bool, default=False
         Boolean flag to indicate if amplitude check is to be skipped.
     times : numpy.ndarray, default=np.zeros(1)
-        Time points at which `amplitudes` defines amplitude values.
+        Time points (s) at which `amplitudes` defines amplitude values.
 
     Returns
     -------

--- a/src/pypulseq/make_gauss_pulse.py
+++ b/src/pypulseq/make_gauss_pulse.py
@@ -43,31 +43,34 @@ def make_gauss_pulse(
     Parameters
     ----------
     flip_angle : float
-        Flip angle in radians.
+        Flip angle in radians (rad).
     apodization : float, default=0
         Apodization.
     bandwidth : float, default=0
-        Bandwidth in Hertz (Hz).
+        Bandwidth in hertz (Hz).
     center_pos : float, default=0.5
-        Position of peak.
+        Position of RF peak between 0 and 1, where 0 means the
+        beginning of the pulse and 1 means the end of the pulse.
     delay : float, default=0
         Delay in seconds (s).
     dwell : float, default=0
+        Temporal sampling step of waveform in seconds (s).
+        If set to 0, will use `system.rf_raster_time`.
     duration : float, default=4e-3
         Duration in seconds (s).
     freq_offset : float, default=0
-        Frequency offset in Hertz (Hz).
+        Frequency offset in hertz (Hz).
     max_grad : float, default=0
-        Maximum gradient strength of accompanying slice select trapezoidal event.
+        Maximum gradient strength (Hz/m) of accompanying slice select trapezoidal event.
     max_slew : float, default=0
-        Maximum slew rate of accompanying slice select trapezoidal event.
+        Maximum slew rate (Hz/m/s) of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
-        Phase offset in Hertz (Hz).
+        Phase offset in radians (rad).
     return_gz : bool, default=False
         Boolean flag to indicate if the slice-selective gradient has to be returned.
     slice_thickness : float, default=0
-        Slice thickness of accompanying slice select trapezoidal event. The slice thickness determines the area of the
-        slice select event.
+        Slice thickness in meters (m) of accompanying slice select trapezoidal event.
+        The slice thickness determines the area of the slice select event.
     system : Opts, default=Opts()
         System limits.
     time_bw_product : float, default=4.0
@@ -77,9 +80,9 @@ def make_gauss_pulse(
         Must be one of 'excitation', 'refocusing', 'inversion',
         'saturation', 'preparation', 'other', 'undefined'.
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
 
     Returns
     -------

--- a/src/pypulseq/make_sigpy_pulse.py
+++ b/src/pypulseq/make_sigpy_pulse.py
@@ -47,26 +47,27 @@ def sigpy_n_seq(
     Parameters
     ----------
     flip_angle : float
-        Flip angle in radians.
+        Flip angle in radians (rad).
     delay : float, optional, default=0
         Delay in seconds (s).
     duration : float, optional, default=4e-3
         Duration in seconds (s).
     freq_offset : float, optional, default=0
-        Frequency offset in Hertz (Hz).
+        Frequency offset in hertz (Hz).
     center_pos : float, optional, default=0.5
-        Position of peak.5 (midway).
+        Position of RF peak between 0 and 1, where 0 means the
+        beginning of the pulse and 1 means the end of the pulse.
     max_grad : float, optional, default=0
-        Maximum gradient strength of accompanying slice select trapezoidal event.
+        Maximum gradient strength (Hz/m) of accompanying slice select trapezoidal event.
     max_slew : float, optional, default=0
-        Maximum slew rate of accompanying slice select trapezoidal event.
+        Maximum slew rate (Hz/m/s) of accompanying slice select trapezoidal event.
     phase_offset : float, optional, default=0
-        Phase offset in Hertz (Hz).
-    return_gz:bool, default=False
+        Phase offset in radians (rad).
+    return_gz : bool, default=False
         Boolean flag to indicate if slice-selective gradient has to be returned.
     slice_thickness : float, optional, default=0
-        Slice thickness of accompanying slice select trapezoidal event. The slice thickness determines the area of the
-        slice select event.
+        Slice thickness in meters (m) of accompanying slice select trapezoidal event.
+        The slice thickness determines the area of the slice select event.
     system : Opts, optional
         System limits. Default is a system limits object initialized to default values.
     time_bw_product : float, optional, default=4
@@ -98,9 +99,9 @@ def sigpy_n_seq(
     plot: bool, optional, default=True
         Show sigpy plot outputs
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
 
     Returns
     -------

--- a/src/pypulseq/make_sinc_pulse.py
+++ b/src/pypulseq/make_sinc_pulse.py
@@ -41,29 +41,31 @@ def make_sinc_pulse(
     Parameters
     ----------
     flip_angle : float
-        Flip angle in radians.
+        Flip angle in radians (rad).
     apodization : float, default=0
         Apodization.
     center_pos : float, default=0.5
-        Position of peak.5 (midway).
+        Position of RF peak between 0 and 1, where 0 means the beginning of the pulse and 1 means the end of the pulse.
     delay : float, default=0
         Delay in seconds (s).
     duration : float, default=4e-3
         Duration in seconds (s).
     dwell : float, default=0
+        Temporal sampling step of waveform in seconds (s).
+        If set to 0, will use `system.rf_raster_time`.
     freq_offset : float, default=0
-        Frequency offset in Hertz (Hz).
+        Frequency offset in hertz (Hz).
     max_grad : float, default=0
-        Maximum gradient strength of accompanying slice select trapezoidal event.
+        Maximum gradient strength (Hz/m) of accompanying slice select trapezoidal event.
     max_slew : float, default=0
-        Maximum slew rate of accompanying slice select trapezoidal event.
+        Maximum slew rate (Hz/m/s) of accompanying slice select trapezoidal event.
     phase_offset : float, default=0
-        Phase offset in Hertz (Hz).
+        Phase offset in radians (rad).
     return_gz : bool, default=False
         Boolean flag to indicate if slice-selective gradient has to be returned.
     slice_thickness : float, default=0
-        Slice thickness of accompanying slice select trapezoidal event. The slice thickness determines the area of the
-        slice select event.
+        Slice thickness in meters (m) of accompanying slice select trapezoidal event.
+        The slice thickness determines the area of the slice select event.
     system : Opts, default=Opts()
         System limits. Default is a system limits object initialized to default values.
     time_bw_product : float, default=4
@@ -73,9 +75,9 @@ def make_sinc_pulse(
         Must be one of 'excitation', 'refocusing', 'inversion',
         'saturation', 'preparation', 'other', 'undefined'.
     freq_ppm : float, default=0
-        PPM frequency offset.
+        PPM frequency offset in parts per million (ppm).
     phase_ppm : float, default=0
-        PPM phase offset.
+        PPM phase offset in radians per megahertz (rad/MHz).
 
     See also `pypulseq.Sequence.sequence.Sequence.add_block()`.
 

--- a/src/pypulseq/opts.py
+++ b/src/pypulseq/opts.py
@@ -13,33 +13,33 @@ class Opts:
     Attributes
     ----------
     adc_dead_time : float, default=0
-        Dead time for ADC readout pulses.
+        Dead time (s) for ADC readout pulses.
     adc_raster_time : float, default=100e-9
-        Raster time for ADC readout pulses.
+        Raster time (s) for ADC readout pulses.
     block_duration_raster : float, default=10e-6
-        Raster time for block durations.
+        Raster time (s) for block durations.
     gamma : float, default=42.576e6
-        Gyromagnetic ratio. Default gamma is specified for Hydrogen.
+        Gyromagnetic ratio (Hz/T). Default gamma is specified for Hydrogen.
     grad_raster_time : float, default=10e-6
-        Raster time for gradient waveforms.
+        Raster time (s) for gradient waveforms.
     grad_unit : str, default='Hz/m'
         Unit of maximum gradient amplitude. Must be one of 'Hz/m', 'mT/m' or 'rad/ms/mm'.
     max_grad : float, default=40 mT/m
-        Maximum gradient amplitude.
+        Maximum gradient amplitude (converted from grad_unit to Hz/m).
     max_slew : float, default=170 T/m/s
-        Maximum slew rate.
+        Maximum slew rate (converted from slew_unit to Hz/m/s).
     rf_dead_time : float, default=0
-        Dead time for radio-frequency pulses.
+        Dead time (s) for radio-frequency pulses.
     rf_raster_time : float, default=1e-6
-        Raster time for radio-frequency pulses.
+        Raster time (s) for radio-frequency pulses.
     rf_ringdown_time : float, default=0
-        Ringdown time for radio-frequency pulses.
+        Ringdown time (s) for radio-frequency pulses.
     adc_samples_limit : int, default=0
         Maximum number of samples for a single ADC object. If 0, no limit is set.
     adc_samples_divisor : int, default=4
         Samples of ADC must be divisible by 'adc_samples_divisor'.
     rise_time : float, default=0
-        Rise time for gradients.
+        Rise time (s) for gradients.
     slew_unit : str, default='Hz/m/s'
         Unit of maximum slew rate. Must be one of 'Hz/m/s', 'mT/m/ms', 'T/m/s' or 'rad/ms/mm/ms'.
     B0 : float, default=1.5

--- a/src/pypulseq/rotate.py
+++ b/src/pypulseq/rotate.py
@@ -27,7 +27,7 @@ def rotate(*args: SimpleNamespace, angle: float, axis: str, system: Union[Opts, 
     axis : str
         Axis about which the gradient(s) will be rotated.
     angle : float
-        Angle by which the gradient(s) will be rotated.
+        Angle in radians (rad) by which the gradient(s) will be rotated.
     args : SimpleNamespace
         Gradient(s).
 

--- a/src/pypulseq/split_gradient.py
+++ b/src/pypulseq/split_gradient.py
@@ -28,13 +28,13 @@ def split_gradient(
     Parameters
     ----------
     grad : SimpleNamespace
-        Gradient event to be split into two gradient waveforms.
+        Gradient event to be split into three gradient waveforms.
     system : Opts, default=Opts()
         System limits.
 
     Returns
     -------
-    grad1, grad2 : SimpleNamespace
+    grad1, grad2, grad3 : SimpleNamespace
         Split gradient waveforms.
 
     Raises

--- a/src/pypulseq/split_gradient_at.py
+++ b/src/pypulseq/split_gradient_at.py
@@ -31,7 +31,7 @@ def split_gradient_at(
     grad : SimpleNamespace
         Gradient event to be split into two gradient events.
     time_point : float
-        Time point at which `grad` will be split into two gradient waveforms.
+        Time point in seconds (s) at which `grad` will be split into two gradient waveforms.
     system : Opts, default=Opts()
         System limits.
 

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -507,7 +507,9 @@ def _seq_plot(
                 else:
                     phase_modulation = adc.phase_modulation
 
-                full_freq_offset = np.atleast_1d(adc.freq_offset + adc.freq_ppm * 1e-6 * seq.system.B0 * seq.system.gamma)
+                full_freq_offset = np.atleast_1d(
+                    adc.freq_offset + adc.freq_ppm * 1e-6 * seq.system.B0 * seq.system.gamma
+                )
                 full_phase_offset = np.atleast_1d(
                     adc.phase_offset + adc.phase_ppm * 1e-6 * seq.system.B0 * seq.system.gamma + phase_modulation
                 )

--- a/src/pypulseq/utils/seq_plot.py
+++ b/src/pypulseq/utils/seq_plot.py
@@ -507,9 +507,9 @@ def _seq_plot(
                 else:
                     phase_modulation = adc.phase_modulation
 
-                full_freq_offset = np.atleast_1d(adc.freq_offset + adc.freq_ppm * 1e-6 * seq.system.B0)
+                full_freq_offset = np.atleast_1d(adc.freq_offset + adc.freq_ppm * 1e-6 * seq.system.B0 * seq.system.gamma)
                 full_phase_offset = np.atleast_1d(
-                    adc.phase_offset + adc.phase_ppm * 1e-6 * seq.system.B0 + phase_modulation
+                    adc.phase_offset + adc.phase_ppm * 1e-6 * seq.system.B0 * seq.system.gamma + phase_modulation
                 )
 
                 sp13.plot(
@@ -555,8 +555,8 @@ def _seq_plot(
                 signal_is_real = max(np.abs(np.imag(signal))) / (max(np.abs(np.real(signal))) + eps) < 1e-6
                 signal_is_imag = max(np.abs(np.real(signal))) / (max(np.abs(np.imag(signal))) + eps) < 1e-6
 
-                full_freq_offset = rf.freq_offset + rf.freq_ppm * 1e-6 * seq.system.B0
-                full_phase_offset = rf.phase_offset + rf.phase_ppm * 1e-6 * seq.system.B0
+                full_freq_offset = rf.freq_offset + rf.freq_ppm * 1e-6 * seq.system.B0 * seq.system.gamma
+                full_phase_offset = rf.phase_offset + rf.phase_ppm * 1e-6 * seq.system.B0 * seq.system.gamma
 
                 # If off-resonant and rectangular (2 samples), interpolate the pulse
                 if len(signal) == 2 and full_freq_offset != 0:


### PR DESCRIPTION
1) In seq_plot.py, added the missing seq.system.gamma from the calculation of full_freq_offset and full_phase_offset from freq_ppm and phase_ppm, respectively.
2) Corrected the issue of doc-strings incorrectly reporting the phase_offset of RF and adc objects being in Hz. The correct units are rad.
3) Updated other missing unit information in the doc-strings.