### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.12", "3.13", "3.14"]
         include-sigpy: [true]
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.12", "3.13", "3.14"]
+        python-version: ["3.8", "3.14"]
         include-sigpy: [true]
 
     steps:

--- a/.github/workflows/report_pytest.yml
+++ b/.github/workflows/report_pytest.yml
@@ -16,11 +16,11 @@ jobs:
       actions: read # Required for downloading artifacts
       pull-requests: write # Required for posting PR comments
     steps:
-      # use the results of python 3.12, consider this as target platform
-      - name: Download PyTest report artifact for Python 3.12
+      # use the results of python 3.14, consider this as target platform
+      - name: Download PyTest report artifact for Python 3.14
         uses: actions/download-artifact@v8
         with:
-          name: pytest-report-3.12-true
+          name: pytest-report-3.14-true
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -79,7 +79,7 @@ jobs:
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          name: pytest-report-3.12-true
+          name: pytest-report-3.14-true
 
       - name: Post PyTest Coverage Comment on push
         id: coverage_comment

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align = "left">
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Python](https://img.shields.io/badge/python-3.7--3.13-blue)](https://pypi.org/project/pypulseq/)
+[![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://pypi.org/project/pypulseq/)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=32322&r=133)
 
 </p>


### PR DESCRIPTION
Fixes #393 

- use Python 3.14 instead of 3.12 as default version for tests and test reports
- reduce test matrix to current minium (3.8) and maximum (3.14) Python version
- update python badge in readme