### PR TITLE
Fix scanner signature error and add binary signature verification

### DIFF
--- a/src/pypulseq/Sequence/read_binary.py
+++ b/src/pypulseq/Sequence/read_binary.py
@@ -283,4 +283,3 @@ def _read_soft_delays(fid, seq):
             seq.soft_delay_hints2.append(hint)
         seq.soft_delay_hints[hint] = int(num)
         seq.soft_delay_library.insert(event_id, np.array([num, offset, factor, hint_id], dtype=float))
-

--- a/src/pypulseq/Sequence/read_binary.py
+++ b/src/pypulseq/Sequence/read_binary.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import numpy as np
+
+from pypulseq.event_lib import EventLibrary
+
+
+def read_binary(self, filename: str) -> None:
+    codes = self.get_binary_codes()
+    with open(filename, 'rb') as fid:
+        magic_num = _read_scalar(fid, np.int64)
+        if magic_num != codes['fileHeader']:
+            raise ValueError('Not a Pulseq binary file')
+        version_major = _read_scalar(fid, np.int64)
+        version_minor = _read_scalar(fid, np.int64)
+        version_revision = _read_scalar(fid, np.int64)
+        if version_major != int(self.version_major):
+            raise ValueError(f'Unsupported version_major {version_major}')
+        if version_minor != int(self.version_minor):
+            raise ValueError(f'Unsupported version_minor {version_minor}')
+        if version_revision != int(self.version_revision):
+            raise ValueError(f'Unsupported version_revision {version_revision}')
+
+        self.version_major = int(version_major)
+        self.version_minor = int(version_minor)
+        self.version_revision = int(version_revision)
+
+        self.block_events = OrderedDict()
+        self.block_durations = {}
+        self.definitions = {}
+        self.grad_library = EventLibrary(numpy_data=True)
+        self.shape_library = EventLibrary(numpy_data=True)
+        self.rf_library = EventLibrary(numpy_data=True)
+        self.adc_library = EventLibrary(numpy_data=True)
+        self.delay_library = EventLibrary(numpy_data=True)
+        self.trigger_library = EventLibrary(numpy_data=True)
+        self.label_set_library = EventLibrary(numpy_data=True)
+        self.label_inc_library = EventLibrary(numpy_data=True)
+        self.extensions_library = EventLibrary(numpy_data=True)
+        self.soft_delay_library = EventLibrary(numpy_data=True)
+        self.soft_delay_hints = {}
+        self.soft_delay_hint_ids = {}
+        self.soft_delay_hints2 = []
+        self.extension_string_idx = []
+        self.extension_numeric_idx = []
+        self.signature_type = ''
+        self.signature_file = ''
+        self.signature_value = ''
+        self.block_cache.clear()
+
+        while True:
+            section_raw = fid.read(8)
+            if not section_raw:
+                break
+            section = int(np.frombuffer(section_raw, dtype=np.int64)[0])
+            if section == codes['section']['definitions']:
+                self.definitions = _read_definitions(fid)
+                _sync_rasters_from_definitions(self)
+            elif section == codes['section']['blocks']:
+                self.block_events, self.block_durations = _read_blocks(fid, self.block_duration_raster)
+            elif section == codes['section']['rf']:
+                _read_rf(fid, self.rf_library)
+            elif section == codes['section']['gradients']:
+                _read_gradients(fid, self.grad_library)
+            elif section == codes['section']['trapezoids']:
+                _read_trapezoids(fid, self.grad_library)
+            elif section == codes['section']['adc']:
+                _read_adc(fid, self.adc_library)
+            elif section == codes['section']['delays']:
+                _read_legacy_delays(fid)
+            elif section == codes['section']['shapes']:
+                self.shape_library = _read_shapes(fid)
+            elif section == codes['section']['extensions']:
+                _read_extensions(fid, self.extensions_library)
+            elif section == codes['section']['triggers']:
+                self.set_extension_string_ID('TRIGGERS', int(_read_scalar(fid, np.int32)))
+                _read_triggers(fid, self.trigger_library)
+            elif section == codes['section']['labelset']:
+                self.set_extension_string_ID('LABELSET', int(_read_scalar(fid, np.int32)))
+                _read_labels(fid, self.label_set_library)
+            elif section == codes['section']['labelinc']:
+                self.set_extension_string_ID('LABELINC', int(_read_scalar(fid, np.int32)))
+                _read_labels(fid, self.label_inc_library)
+            elif section == codes['section']['softdelays']:
+                self.set_extension_string_ID('DELAYS', int(_read_scalar(fid, np.int32)))
+                _read_soft_delays(fid, self)
+            elif section == codes['section']['signature']:
+                sig_type, sig_value = _read_signature(fid)
+                self.signature_type = sig_type
+                self.signature_file = 'bin'
+                self.signature_value = sig_value
+            else:
+                raise ValueError(f'Unknown section code: {section:x}')
+
+
+def _sync_rasters_from_definitions(self) -> None:
+    if 'GradientRasterTime' in self.definitions:
+        self.grad_raster_time = float(np.asarray(self.definitions['GradientRasterTime']).reshape(-1)[0])
+    if 'RadiofrequencyRasterTime' in self.definitions:
+        self.rf_raster_time = float(np.asarray(self.definitions['RadiofrequencyRasterTime']).reshape(-1)[0])
+    if 'AdcRasterTime' in self.definitions:
+        self.adc_raster_time = float(np.asarray(self.definitions['AdcRasterTime']).reshape(-1)[0])
+    if 'BlockDurationRaster' in self.definitions:
+        self.block_duration_raster = float(np.asarray(self.definitions['BlockDurationRaster']).reshape(-1)[0])
+
+
+def _read_scalar(fid, dtype):
+    return np.frombuffer(fid.read(np.dtype(dtype).itemsize), dtype=dtype)[0]
+
+
+def _read_definitions(fid):
+    defs = {}
+    num_defs = int(_read_scalar(fid, np.int64))
+    for _ in range(num_defs):
+        key, legacy_format = _read_definition_key(fid)
+        if legacy_format:
+            count = int(np.frombuffer(fid.read(1), dtype=np.int8)[0])
+        else:
+            count = int(_read_scalar(fid, np.int32))
+        value_type = fid.read(1).decode('ascii')
+        if value_type == 'f':
+            values = np.frombuffer(fid.read(8 * count), dtype=np.float64).copy()
+        elif value_type == 'i':
+            values = np.frombuffer(fid.read(4 * count), dtype=np.int32).copy()
+        elif value_type == 'c':
+            values = fid.read(count).decode('ascii')
+            if values.endswith('\x00'):
+                values = values[:-1]
+        else:
+            raise ValueError(f'Unknown definition type: {value_type}')
+        defs[key] = values
+    return defs
+
+
+def _read_definition_key(fid):
+    pos = fid.tell()
+    raw_len = fid.read(4)
+    if len(raw_len) != 4:
+        raise EOFError('Unexpected end of file while reading definition key length')
+    key_len = int(np.frombuffer(raw_len, dtype=np.int32)[0])
+    if 0 < key_len < 4096:
+        key_bytes = fid.read(key_len)
+        try:
+            return key_bytes.decode('ascii'), False
+        except UnicodeDecodeError:
+            pass
+
+    fid.seek(pos)
+    key_bytes = bytearray()
+    while True:
+        c = fid.read(1)
+        if c == b'':
+            raise EOFError('Unexpected end of file while reading legacy definition key')
+        if c == b'\x00':
+            break
+        key_bytes.extend(c)
+    return key_bytes.decode('ascii'), True
+
+
+def _read_signature(fid):
+    type_len = int(_read_scalar(fid, np.int32))
+    sig_type = fid.read(type_len).decode('ascii')
+    hash_len = int(_read_scalar(fid, np.int32))
+    sig_value = fid.read(hash_len).hex()
+    _read_scalar(fid, np.int64)
+    return sig_type, sig_value
+
+
+def _read_blocks(fid, block_duration_raster):
+    num_blocks = int(_read_scalar(fid, np.int64))
+    events = OrderedDict()
+    durations = {}
+    for ii in range(num_blocks):
+        duration_raster = float(_read_scalar(fid, np.int64))
+        event_ids = np.frombuffer(fid.read(4 * 6), dtype=np.int32).copy()
+        events[ii + 1] = np.concatenate(([0], event_ids)).astype(np.int32)
+        durations[ii + 1] = duration_raster * block_duration_raster
+    return events, durations
+
+
+def _read_rf(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        amp = float(_read_scalar(fid, np.float64))
+        shape_ids = np.frombuffer(fid.read(4 * 3), dtype=np.int32).astype(float)
+        center = float(_read_scalar(fid, np.int64)) * 1e-12
+        delay = float(_read_scalar(fid, np.int64)) * 1e-12
+        offsets = np.frombuffer(fid.read(8 * 4), dtype=np.float64).copy()
+        use = fid.read(1).decode('ascii')
+        library.insert(event_id, np.concatenate(([amp], shape_ids, [center, delay], offsets)), use)
+
+
+def _read_gradients(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        amp_first_last = np.frombuffer(fid.read(8 * 3), dtype=np.float64).copy()
+        shape_ids = np.frombuffer(fid.read(4 * 2), dtype=np.int32).astype(float)
+        delay = float(_read_scalar(fid, np.int64)) * 1e-12
+        library.insert(event_id, np.concatenate((amp_first_last, shape_ids, [delay])), 'g')
+
+
+def _read_trapezoids(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        amp = float(_read_scalar(fid, np.float64))
+        times = np.frombuffer(fid.read(8 * 4), dtype=np.int64).astype(float) * 1e-12
+        library.insert(event_id, np.concatenate(([amp], times)), 't')
+
+
+def _read_adc(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        num = float(_read_scalar(fid, np.int64))
+        dwell = float(_read_scalar(fid, np.int64)) * 1e-12
+        delay = float(_read_scalar(fid, np.int64)) * 1e-12
+        offsets = np.frombuffer(fid.read(8 * 4), dtype=np.float64).copy()
+        phase_id = float(_read_scalar(fid, np.int32))
+        library.insert(event_id, np.concatenate(([num, dwell, delay], offsets, [phase_id])))
+
+
+def _read_legacy_delays(fid):
+    num_events = int(_read_scalar(fid, np.int64))
+    fid.read(num_events * (4 + 8))
+
+
+def _read_shapes(fid):
+    shape_library = EventLibrary(numpy_data=True)
+    num_shapes = int(_read_scalar(fid, np.int64))
+    for _ in range(num_shapes):
+        shape_id = int(_read_scalar(fid, np.int32))
+        num_uncompressed = int(_read_scalar(fid, np.int64))
+        num_compressed = int(_read_scalar(fid, np.int64))
+        data = np.frombuffer(fid.read(4 * num_compressed), dtype=np.float32).astype(float)
+        shape_library.insert(shape_id, np.concatenate(([num_uncompressed], data)))
+    return shape_library
+
+
+def _read_extensions(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        data = np.frombuffer(fid.read(4 * 3), dtype=np.int32).copy()
+        library.insert(event_id, data)
+
+
+def _read_triggers(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        type_channel = np.frombuffer(fid.read(4 * 2), dtype=np.int32).astype(float)
+        delay_duration = np.frombuffer(fid.read(8 * 2), dtype=np.int64).astype(float) * 1e-12
+        library.insert(event_id, np.concatenate((type_channel, delay_duration)))
+
+
+def _read_labels(fid, library):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        data = np.frombuffer(fid.read(4 * 2), dtype=np.int32).copy()
+        library.insert(event_id, data)
+
+
+def _read_soft_delays(fid, seq):
+    num_events = int(_read_scalar(fid, np.int64))
+    for _ in range(num_events):
+        event_id = int(_read_scalar(fid, np.int32))
+        num = float(_read_scalar(fid, np.int32))
+        offset = float(_read_scalar(fid, np.int64)) * 1e-12
+        factor = float(_read_scalar(fid, np.float64))
+        hint_len = int(_read_scalar(fid, np.int32))
+        hint = fid.read(hint_len).decode('ascii')
+        if hint in seq.soft_delay_hint_ids:
+            hint_id = seq.soft_delay_hint_ids[hint]
+        else:
+            hint_id = len(seq.soft_delay_hints2) + 1
+            seq.soft_delay_hint_ids[hint] = hint_id
+            seq.soft_delay_hints2.append(hint)
+        seq.soft_delay_hints[hint] = int(num)
+        seq.soft_delay_library.insert(event_id, np.array([num, offset, factor, hint_id], dtype=float))
+

--- a/src/pypulseq/Sequence/read_seq.py
+++ b/src/pypulseq/Sequence/read_seq.py
@@ -97,7 +97,7 @@ def read(self, path: str, detect_rf_use: Union[bool, None] = None, remove_duplic
                 self.signature_type = temp_sign_defs['Type']
             if 'Hash' in temp_sign_defs:
                 self.signature_value = temp_sign_defs['Hash']
-                self.signature_file = 'Text'
+                self.signature_file = 'text'
         elif section == '[VERSION]':
             file_version_major, file_version_minor, file_version_revision = __read_version(input_file)
             file_version_combined = 1000000 * file_version_major + 1000 * file_version_minor + file_version_revision

--- a/src/pypulseq/Sequence/sequence.py
+++ b/src/pypulseq/Sequence/sequence.py
@@ -27,7 +27,9 @@ from pypulseq.Sequence.calc_grad_spectrum import calculate_gradient_spectrum
 from pypulseq.Sequence.calc_pns import calc_pns
 from pypulseq.Sequence.ext_test_report import ext_test_report, ext_test_report_data
 from pypulseq.Sequence.install import detect_scanner
+from pypulseq.Sequence.read_binary import read_binary as read_binary_seq
 from pypulseq.Sequence.read_seq import read
+from pypulseq.Sequence.write_binary import write_binary as write_binary_seq
 from pypulseq.Sequence.write_seq import write as write_seq
 from pypulseq.Sequence.write_seq import write_v141 as write_seq_v141
 from pypulseq.utils.cumsum import cumsum
@@ -100,6 +102,8 @@ class Sequence:
         self.extension_numeric_idx = []
         self.extension_string_idx = []
         self.soft_delay_hints = {}
+        self.soft_delay_hint_ids = {}
+        self.soft_delay_hints2 = []
 
     def __str__(self) -> str:
         s = 'Sequence:'
@@ -1148,6 +1152,23 @@ class Sequence:
         # Initialize next free block ID
         self.next_free_block_ID = (max(self.block_events) + 1) if self.block_events else 1
 
+    def read_binary(self, file_path: str) -> None:
+        """
+        Read binary `.bseq` file from `file_path`.
+
+        Parameters
+        ----------
+        file_path : str
+            Path to `.bseq` file to be read.
+        """
+        if self.use_block_cache:
+            self.block_cache.clear()
+
+        read_binary_seq(self, filename=file_path)
+
+        # Initialize next free block ID
+        self.next_free_block_ID = (max(self.block_events) + 1) if self.block_events else 1
+
     def register_adc_event(self, event: EventLibrary) -> int:
         return block.register_adc_event(self, event)
 
@@ -1869,3 +1890,50 @@ class Sequence:
             return signature
         else:
             return None
+
+    def write_binary(self, name: str, create_signature: bool = True) -> Union[str, None]:
+        """
+        Write the sequence data to the given filename using the binary Pulseq file format.
+
+        Parameters
+        ----------
+        name : str
+            Filename of `.bseq` file to be written to disk.
+        create_signature : bool, default=True
+            Boolean flag to indicate if the file has to be signed.
+
+        Returns
+        -------
+        signature or None : If create_signature is True, it returns the written `.bseq` file's signature as a string,
+        otherwise it returns None.
+        """
+        return write_binary_seq(self, name, create_signature=create_signature)
+
+    @staticmethod
+    def get_binary_codes():
+        def signed_int64(value):
+            value &= (1 << 64) - 1
+            if value >= (1 << 63):
+                value -= 1 << 64
+            return value
+
+        prefix = 0xFFFFFFFF << 32
+        return {
+            'fileHeader': int.from_bytes(b'\x01pulseq\x02', byteorder='little', signed=True),
+            'section': {
+                'definitions': signed_int64(prefix | 1),
+                'blocks': signed_int64(prefix | 2),
+                'rf': signed_int64(prefix | 3),
+                'gradients': signed_int64(prefix | 4),
+                'trapezoids': signed_int64(prefix | 5),
+                'adc': signed_int64(prefix | 6),
+                'delays': signed_int64(prefix | 7),
+                'shapes': signed_int64(prefix | 8),
+                'extensions': signed_int64(prefix | 9),
+                'triggers': signed_int64(prefix | 10),
+                'labelset': signed_int64(prefix | 11),
+                'labelinc': signed_int64(prefix | 12),
+                'softdelays': signed_int64(prefix | 13),
+                'signature': signed_int64(prefix | 0x00FFFFFF),
+            },
+        }

--- a/src/pypulseq/Sequence/write_binary.py
+++ b/src/pypulseq/Sequence/write_binary.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Union
+
+import numpy as np
+
+
+def write_binary(self, filename: str, create_signature: bool = True) -> Union[str, None]:
+    codes = self.get_binary_codes()
+    with open(filename, 'wb') as fid:
+        _write_int64(fid, codes['fileHeader'])
+        _write_int64(fid, int(self.version_major))
+        _write_int64(fid, int(self.version_minor))
+        _write_int64(fid, int(self.version_revision))
+
+        if self.definitions:
+            _write_int64(fid, codes['section']['definitions'])
+            _write_int64(fid, len(self.definitions))
+            for key, val in self.definitions.items():
+                key_bytes = key.encode('ascii')
+                _write_int32(fid, len(key_bytes))
+                fid.write(key_bytes)
+                if isinstance(val, str):
+                    data = val.encode('ascii')
+                    _write_int32(fid, len(data))
+                    fid.write(b'c')
+                    fid.write(data)
+                else:
+                    arr = np.asarray(val)
+                    _write_int32(fid, arr.size)
+                    if np.issubdtype(arr.dtype, np.integer):
+                        fid.write(b'i')
+                        fid.write(arr.astype(np.int32).reshape(-1).tobytes())
+                    elif np.issubdtype(arr.dtype, np.floating):
+                        fid.write(b'f')
+                        fid.write(arr.astype(np.float64).reshape(-1).tobytes())
+                    else:
+                        raise TypeError(f'unknown type of the value type for {key}')
+
+        _write_int64(fid, codes['section']['blocks'])
+        _write_int64(fid, len(self.block_events))
+        for block_id, block_event in self.block_events.items():
+            block_event = np.asarray(block_event, dtype=np.int32).reshape(-1)
+            block_duration = self.block_durations[block_id] / self.block_duration_raster
+            block_duration_raster = round(block_duration)
+            if abs(block_duration_raster - block_duration) >= 1e-6:
+                raise AssertionError('Block duration is not aligned to block_duration_raster')
+            _write_int64(fid, block_duration_raster)
+            fid.write(block_event[1:7].astype(np.int32).tobytes())
+
+        if self.rf_library.data:
+            _write_int64(fid, codes['section']['rf'])
+            keys = list(self.rf_library.data.keys())
+            _write_int64(fid, len(keys))
+            for k in keys:
+                data = np.asarray(self.rf_library.data[k], dtype=float)
+                _write_int32(fid, k)
+                _write_float64(fid, data[0])
+                fid.write(data[1:4].astype(np.int32).tobytes())
+                _write_int64(fid, round(data[4] * 1e12))
+                _write_int64(fid, round(data[5] * 1e12))
+                fid.write(data[6:10].astype(np.float64).tobytes())
+                fid.write(str(self.rf_library.type.get(k, 'u'))[:1].encode('ascii'))
+
+        arb_keys = [k for k, t in self.grad_library.type.items() if t == 'g']
+        trap_keys = [k for k, t in self.grad_library.type.items() if t == 't']
+
+        if arb_keys:
+            _write_int64(fid, codes['section']['gradients'])
+            _write_int64(fid, len(arb_keys))
+            for k in arb_keys:
+                data = np.asarray(self.grad_library.data[k], dtype=float)
+                _write_int32(fid, k)
+                fid.write(data[0:3].astype(np.float64).tobytes())
+                fid.write(data[3:5].astype(np.int32).tobytes())
+                _write_int64(fid, round(data[5] * 1e12))
+
+        if trap_keys:
+            _write_int64(fid, codes['section']['trapezoids'])
+            _write_int64(fid, len(trap_keys))
+            for k in trap_keys:
+                data = np.asarray(self.grad_library.data[k], dtype=float)
+                _write_int32(fid, k)
+                _write_float64(fid, data[0])
+                fid.write(np.round(data[1:5] * 1e12).astype(np.int64).tobytes())
+
+        if self.adc_library.data:
+            _write_int64(fid, codes['section']['adc'])
+            keys = list(self.adc_library.data.keys())
+            _write_int64(fid, len(keys))
+            for k in keys:
+                data = np.asarray(self.adc_library.data[k], dtype=float)
+                _write_int32(fid, k)
+                _write_int64(fid, round(data[0]))
+                _write_int64(fid, round(data[1] * 1e12))
+                _write_int64(fid, round(data[2] * 1e12))
+                fid.write(data[3:7].astype(np.float64).tobytes())
+                _write_int32(fid, round(data[7]))
+
+        if self.shape_library.data:
+            _write_int64(fid, codes['section']['shapes'])
+            keys = list(self.shape_library.data.keys())
+            _write_int64(fid, len(keys))
+            for k in keys:
+                shape = np.asarray(self.shape_library.data[k], dtype=float)
+                num_samples = int(shape[0])
+                data = shape[1:]
+                _write_int32(fid, k)
+                _write_int64(fid, num_samples)
+                _write_int64(fid, len(data))
+                fid.write(data.astype(np.float32).tobytes())
+
+        if self.extensions_library.data:
+            _write_int64(fid, codes['section']['extensions'])
+            keys = list(self.extensions_library.data.keys())
+            _write_int64(fid, len(keys))
+            for k in keys:
+                _write_int32(fid, k)
+                fid.write(np.asarray(self.extensions_library.data[k], dtype=np.int32).reshape(-1).tobytes())
+
+        if self.trigger_library.data:
+            _write_int64(fid, codes['section']['triggers'])
+            _write_int32(fid, self.get_extension_type_ID('TRIGGERS'))
+            keys = list(self.trigger_library.data.keys())
+            _write_int64(fid, len(keys))
+            for k in keys:
+                data = np.asarray(self.trigger_library.data[k], dtype=float)
+                _write_int32(fid, k)
+                fid.write(data[0:2].astype(np.int32).tobytes())
+                fid.write(np.round(data[2:4] * 1e12).astype(np.int64).tobytes())
+
+        if self.label_set_library.data:
+            _write_int64(fid, codes['section']['labelset'])
+            _write_int32(fid, self.get_extension_type_ID('LABELSET'))
+            _write_int64(fid, len(self.label_set_library.data))
+            for k, data in self.label_set_library.data.items():
+                _write_int32(fid, k)
+                fid.write(np.asarray(data, dtype=np.int32).reshape(-1).tobytes())
+
+        if self.label_inc_library.data:
+            _write_int64(fid, codes['section']['labelinc'])
+            _write_int32(fid, self.get_extension_type_ID('LABELINC'))
+            _write_int64(fid, len(self.label_inc_library.data))
+            for k, data in self.label_inc_library.data.items():
+                _write_int32(fid, k)
+                fid.write(np.asarray(data, dtype=np.int32).reshape(-1).tobytes())
+
+        if self.soft_delay_library.data:
+            _write_int64(fid, codes['section']['softdelays'])
+            _write_int32(fid, self.get_extension_type_ID('DELAYS'))
+            _write_int64(fid, len(self.soft_delay_library.data))
+            for k, data in self.soft_delay_library.data.items():
+                data = np.asarray(data, dtype=float)
+                hint = self.soft_delay_hints2[int(data[3]) - 1]
+                _write_int32(fid, k)
+                _write_int32(fid, round(data[0]))
+                _write_int64(fid, round(data[1] * 1e12))
+                _write_float64(fid, data[2])
+                _write_int32(fid, len(hint))
+                fid.write(hint.encode('ascii'))
+
+    if create_signature:
+        with open(filename, 'rb') as fid:
+            payload = fid.read()
+        md5_hash = hashlib.md5(payload).hexdigest()
+
+        self.signature_type = 'md5'
+        self.signature_file = 'bin'
+        self.signature_value = md5_hash
+
+        with open(filename, 'ab') as fid:
+            signed_len = fid.tell()
+            _write_int64(fid, codes['section']['signature'])
+            sig_type = self.signature_type.encode('ascii')
+            _write_int32(fid, len(sig_type))
+            fid.write(sig_type)
+            sig_bytes = bytes.fromhex(md5_hash)
+            _write_int32(fid, len(sig_bytes))
+            fid.write(sig_bytes)
+            _write_int64(fid, signed_len)
+
+        return md5_hash
+
+    return None
+
+
+def _write_int8(fid: Any, value: int) -> None:
+    fid.write(np.asarray(value, dtype=np.int8).tobytes())
+
+
+def _write_int32(fid: Any, value: int) -> None:
+    fid.write(np.asarray(value, dtype=np.int32).tobytes())
+
+
+def _write_int64(fid: Any, value: int) -> None:
+    fid.write(np.asarray(value, dtype=np.int64).tobytes())
+
+
+def _write_float64(fid: Any, value: float) -> None:
+    fid.write(np.asarray(value, dtype=np.float64).tobytes())

--- a/src/pypulseq/Sequence/write_seq.py
+++ b/src/pypulseq/Sequence/write_seq.py
@@ -263,11 +263,16 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
-            output_file.write('# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n')
-            output_file.write('# section was added. It can be reproduced/verified with md5sum if the file\n')
-            output_file.write('# trimmed to the position right above [SIGNATURE]. The new line character\n')
-            output_file.write('# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n')
-            output_file.write('# for recalculating/verification)\n')
+            output_file.write(
+                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE] section was added\n'
+            )
+            output_file.write(
+                '# It can be reproduced/verified with md5sum if the file trimmed to the position right above [SIGNATURE]\n'
+            )
+            output_file.write(
+                '# The new line character preceding [SIGNATURE] BELONGS to the signature (and needs to be stripped away for '
+                'recalculating/verification)\n'
+            )
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')
 
@@ -518,11 +523,16 @@ def write_v141(self, file_name: Union[str, Path], create_signature, remove_dupli
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
-            output_file.write('# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n')
-            output_file.write('# section was added. It can be reproduced/verified with md5sum if the file\n')
-            output_file.write('# trimmed to the position right above [SIGNATURE]. The new line character\n')
-            output_file.write('# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n')
-            output_file.write('# for recalculating/verification)\n')
+            output_file.write(
+                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE] section was added\n'
+            )
+            output_file.write(
+                '# It can be reproduced/verified with md5sum if the file trimmed to the position right above [SIGNATURE]\n'
+            )
+            output_file.write(
+                '# The new line character preceding [SIGNATURE] BELONGS to the signature (and needs to be stripped away for '
+                'recalculating/verification)\n'
+            )
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')
 

--- a/src/pypulseq/Sequence/write_seq.py
+++ b/src/pypulseq/Sequence/write_seq.py
@@ -263,18 +263,10 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
-            output_file.write(
-                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n'
-            )
-            output_file.write(
-                '# section was added. It can be reproduced/verified with md5sum if the file\n'
-            )
-            output_file.write(
-                '# trimmed to the position right above [SIGNATURE]. The new line character\n'
-            )
-            output_file.write(
-                '# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n'
-            )
+            output_file.write('# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n')
+            output_file.write('# section was added. It can be reproduced/verified with md5sum if the file\n')
+            output_file.write('# trimmed to the position right above [SIGNATURE]. The new line character\n')
+            output_file.write('# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n')
             output_file.write('# for recalculating/verification)\n')
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')
@@ -526,18 +518,10 @@ def write_v141(self, file_name: Union[str, Path], create_signature, remove_dupli
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
-            output_file.write(
-                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n'
-            )
-            output_file.write(
-                '# section was added. It can be reproduced/verified with md5sum if the file\n'
-            )
-            output_file.write(
-                '# trimmed to the position right above [SIGNATURE]. The new line character\n'
-            )
-            output_file.write(
-                '# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n'
-            )
+            output_file.write('# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n')
+            output_file.write('# section was added. It can be reproduced/verified with md5sum if the file\n')
+            output_file.write('# trimmed to the position right above [SIGNATURE]. The new line character\n')
+            output_file.write('# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n')
             output_file.write('# for recalculating/verification)\n')
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')

--- a/src/pypulseq/Sequence/write_seq.py
+++ b/src/pypulseq/Sequence/write_seq.py
@@ -255,24 +255,27 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
 
     if create_signature:  # Sign the file
         # Calculate digest
-        with open(file_name, 'r') as output_file:
+        with open(file_name, 'rb') as output_file:
             buffer = output_file.read()
 
-            md5 = hashlib.md5(buffer.encode('utf-8')).hexdigest()
+            md5 = hashlib.md5(buffer).hexdigest()
 
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
             output_file.write(
-                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE] section was added\n'
+                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n'
             )
             output_file.write(
-                '# It can be reproduced/verified with md5sum if the file trimmed to the position right above [SIGNATURE]\n'
+                '# section was added. It can be reproduced/verified with md5sum if the file\n'
             )
             output_file.write(
-                '# The new line character preceding [SIGNATURE] BELONGS to the signature (and needs to be stripped away for '
-                'recalculating/verification)\n'
+                '# trimmed to the position right above [SIGNATURE]. The new line character\n'
             )
+            output_file.write(
+                '# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n'
+            )
+            output_file.write('# for recalculating/verification)\n')
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')
 
@@ -515,24 +518,27 @@ def write_v141(self, file_name: Union[str, Path], create_signature, remove_dupli
 
     if create_signature:  # Sign the file
         # Calculate digest
-        with open(file_name, 'r') as output_file:
+        with open(file_name, 'rb') as output_file:
             buffer = output_file.read()
 
-            md5 = hashlib.md5(buffer.encode('utf-8')).hexdigest()
+            md5 = hashlib.md5(buffer).hexdigest()
 
         # Write signature
         with open(file_name, 'a') as output_file:
             output_file.write('\n[SIGNATURE]\n')
             output_file.write(
-                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE] section was added\n'
+                '# This is the hash of the Pulseq file, calculated right before the [SIGNATURE]\n'
             )
             output_file.write(
-                '# It can be reproduced/verified with md5sum if the file trimmed to the position right above [SIGNATURE]\n'
+                '# section was added. It can be reproduced/verified with md5sum if the file\n'
             )
             output_file.write(
-                '# The new line character preceding [SIGNATURE] BELONGS to the signature (and needs to be stripped away for '
-                'recalculating/verification)\n'
+                '# trimmed to the position right above [SIGNATURE]. The new line character\n'
             )
+            output_file.write(
+                '# preceding [SIGNATURE] BELONGS to the signature (and needs to be sripped away\n'
+            )
+            output_file.write('# for recalculating/verification)\n')
             output_file.write('Type md5\n')
             output_file.write(f'Hash {md5}\n')
 

--- a/src/pypulseq/__init__.py
+++ b/src/pypulseq/__init__.py
@@ -65,3 +65,4 @@ from pypulseq.split_gradient_at import split_gradient_at
 from pypulseq.supported_labels_rf_use import get_supported_labels
 from pypulseq.traj_to_grad import traj_to_grad
 from pypulseq.utils.tracing import enable_trace, disable_trace
+from pypulseq.verify_file_signature import verify_file_signature

--- a/src/pypulseq/verify_file_signature.py
+++ b/src/pypulseq/verify_file_signature.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Tuple, Union
+
+
+def verify_file_signature(pulseq_file: Union[str, Path]) -> Tuple[bool, str, str]:
+    """
+    Verify the MD5 signature stored in a Pulseq text or binary file.
+
+    Returns
+    -------
+    result, stored_signature, computed_signature
+        ``result`` is True when the stored and recomputed signatures match.
+    """
+    path = Path(pulseq_file)
+    data = path.read_bytes()
+    if len(data) < 8:
+        raise ValueError(f'File is too short to contain a Pulseq signature: {path}')
+
+    from pypulseq.Sequence.sequence import Sequence
+
+    codes = Sequence.get_binary_codes()
+    magic_num = int.from_bytes(data[:8], byteorder='little', signed=True)
+    if magic_num == codes['fileHeader']:
+        stored_signature, signed_len = _read_binary_signature(data, codes)
+    else:
+        stored_signature, signed_len = _read_text_signature(data)
+
+    computed_signature = hashlib.md5(data[:signed_len]).hexdigest()
+    return computed_signature == stored_signature, stored_signature, computed_signature
+
+
+def _read_binary_signature(data: bytes, codes) -> Tuple[str, int]:
+    if len(data) < 16:
+        raise ValueError('Binary Pulseq file is too short to contain a signature')
+
+    signed_len = int.from_bytes(data[-8:], byteorder='little', signed=True)
+    if signed_len < 0 or signed_len + 8 > len(data):
+        raise ValueError('Invalid binary Pulseq signature length')
+
+    pos = signed_len
+    section = int.from_bytes(data[pos : pos + 8], byteorder='little', signed=True)
+    pos += 8
+    if section != codes['section']['signature']:
+        raise ValueError('Binary Pulseq signature section not found')
+
+    type_len = int.from_bytes(data[pos : pos + 4], byteorder='little', signed=True)
+    pos += 4
+    sig_type = data[pos : pos + type_len].decode('ascii')
+    pos += type_len
+    if sig_type.lower() != 'md5':
+        raise ValueError(f'Unsupported signature type: {sig_type}')
+
+    hash_len = int.from_bytes(data[pos : pos + 4], byteorder='little', signed=True)
+    pos += 4
+    return data[pos : pos + hash_len].hex(), signed_len
+
+
+def _read_text_signature(data: bytes) -> Tuple[str, int]:
+    marker_pos = data.find(b'\n[SIGNATURE]\n')
+    marker_len = len(b'\n[SIGNATURE]\n')
+    if marker_pos < 0:
+        marker_pos = data.find(b'\r\n[SIGNATURE]\r\n')
+        marker_len = len(b'\r\n[SIGNATURE]\r\n')
+    if marker_pos < 0:
+        raise ValueError('Text Pulseq signature section not found')
+
+    sig_type = ''
+    sig_hash = ''
+    for raw_line in data[marker_pos + marker_len :].splitlines():
+        line = raw_line.decode('ascii', errors='ignore').strip()
+        if not line or line.startswith('#'):
+            continue
+        if line.startswith('Type '):
+            sig_type = line[5:].strip()
+        elif line.startswith('Hash '):
+            sig_hash = line[5:].strip().lower()
+
+    if sig_type.lower() != 'md5' or not sig_hash:
+        raise ValueError('Failed to read text Pulseq MD5 signature')
+
+    return sig_hash, marker_pos

--- a/tests/test_binary_signature.py
+++ b/tests/test_binary_signature.py
@@ -1,5 +1,6 @@
 import math
 import tempfile
+from pathlib import Path
 
 import pypulseq as pp
 

--- a/tests/test_binary_signature.py
+++ b/tests/test_binary_signature.py
@@ -1,5 +1,6 @@
 import math
 import tempfile
+
 import pypulseq as pp
 
 
@@ -49,6 +50,6 @@ def make_test_sequences():
     return [seq1, seq2]
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     with tempfile.TemporaryDirectory() as tmp_dir:
         test_binary_signature_roundtrip_multiple_sequences(Path(tmp_dir))

--- a/tests/test_binary_signature.py
+++ b/tests/test_binary_signature.py
@@ -1,0 +1,54 @@
+import math
+import tempfile
+import pypulseq as pp
+
+
+def test_binary_signature_roundtrip_multiple_sequences(tmp_path):
+    seqs = make_test_sequences()
+
+    for index, seq in enumerate(seqs):
+        path_bin = tmp_path / f'signature_{index + 1}.bseq'
+
+        seq.write_binary(path_bin)
+
+        seq_loaded = pp.Sequence()
+        seq_loaded.read_binary(path_bin)
+
+        signature_valid, stored_signature, computed_signature = pp.verify_file_signature(path_bin)
+
+        assert seq_loaded.signature_type.lower() == 'md5'
+        assert seq_loaded.signature_file.lower() == 'bin'
+        assert signature_valid
+        assert stored_signature == computed_signature
+
+    print('Test function test_binary_signature_roundtrip_multiple_sequences completed successfully')
+
+
+def make_test_sequences():
+    seq1 = pp.Sequence()
+    gx = pp.make_trapezoid('x', area=1000, duration=1e-3)
+    adc = pp.make_adc(128, duration=1e-3)
+    seq1.add_block(gx, adc)
+    seq1.add_block(pp.make_delay(2e-3))
+
+    seq2 = pp.Sequence()
+    rf, gz, _ = pp.make_sinc_pulse(
+        math.pi / 2,
+        duration=2e-3,
+        slice_thickness=5e-3,
+        apodization=0.5,
+        time_bw_product=4,
+        use='excitation',
+        return_gz=True,
+    )
+    gz_reph = pp.make_trapezoid('z', area=-gz.area / 2, duration=1e-3)
+    seq2.add_block(rf, gz)
+    seq2.add_block(gz_reph)
+    seq2.add_block(pp.make_delay(1e-3))
+
+    return [seq1, seq2]
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        test_binary_signature_roundtrip_multiple_sequences(Path(tmp_dir))


### PR DESCRIPTION
* `read_binary.py` and `write_binary.py`:
  Added binary `.bseq` read/write support with MD5 signature serialization and deserialization.

* `read_seq.py` and `write_seq.py`:
  Updated text `.seq` signature handling. `write_seq.py` now computes the MD5 hash from raw file bytes before appending `[SIGNATURE]`, and `read_seq.py` restores the signature metadata consistently when reading signed text files.

* `verify_file_signature.py`:
  Added a helper that recomputes the MD5 hash over the signed portion of text or binary Pulseq files and compares it with the stored signature, matching the MD5 verification behavior of MATLAB `verifyFileSignature.m`.

* `sequence.py`:
  Exposed `read_binary()` and `write_binary()` on `Sequence`, and added shared binary section codes used by binary IO and signature verification.

* `test_binary_signature.py`:
  Added binary signature roundtrip coverage for `write_binary()`, `read_binary()`, and `verify_file_signature()`, matching the binary signature roundtrip covered by MATLAB `testBinarySignature.m`.