### PR TITLE
FIX: Format RF delay as .0f instead of g in write_seq

### DIFF
--- a/src/pypulseq/Sequence/write_seq.py
+++ b/src/pypulseq/Sequence/write_seq.py
@@ -108,7 +108,7 @@ def write(self, file_name: Union[str, Path], create_signature, remove_duplicates
             output_file.write(f'# Field "use" is the initial of: {" ".join(get_supported_rf_uses()).strip()}\n')
             output_file.write('[RF]\n')
             id_format_str = (
-                '{:.0f} {:12g} {:.0f} {:.0f} {:.0f} {:g} {:g} {:g} {:g} {:g} {:g} {:s}\n'  # Refer lines 20-21
+                '{:.0f} {:12g} {:.0f} {:.0f} {:.0f} {:g} {:.0f} {:g} {:g} {:g} {:g} {:s}\n'  # Refer lines 20-21
             )
             for k in self.rf_library.data:
                 lib_data1 = self.rf_library.data[k][0:4]
@@ -376,7 +376,7 @@ def write_v141(self, file_name: Union[str, Path], create_signature, remove_dupli
             output_file.write('# id amplitude mag_id phase_id time_shape_id delay freq phase\n')
             output_file.write('# ..        Hz   ....     ....          ....    us   Hz   rad\n')
             output_file.write('[RF]\n')
-            id_format_str = '{:.0f} {:12g} {:.0f} {:.0f} {:.0f} {:g} {:g} {:g}\n'  # Refer lines 20-21
+            id_format_str = '{:.0f} {:12g} {:.0f} {:.0f} {:.0f} {:.0f} {:g} {:g}\n'  # Refer lines 20-21
             for k in self.rf_library.data:
                 lib = self.rf_library.data[k]
                 data1 = lib[0:4]


### PR DESCRIPTION
**Summary**
Format RF delay as .0f instead of g in write_seq to prevent scientific notation for large values. All the other events have formatted the delay as `{:.0f}` except RF.

**Problem**
The RF delay attribute was formatted with `{:g}`, which switches to scientific notation for large values (e.g., 1e+06). The C++ reader parses this field as an integer and fails on scientific notation input.
<img width="1506" height="188" alt="img_v3_0212q_ecd43821-d6ab-4aae-bd36-07254727cfcg" src="https://github.com/user-attachments/assets/d7c31351-ba4d-4f98-b06b-7a603fc8aade" />


**Change**
Replace `{:g}` with `{:.0f}` for the RF delay field in write_seq, ensuring the value is always written as a plain integer-style decimal.
<img width="1674" height="179" alt="img_v3_0212q_cf1f6d41-47b4-4184-a7b6-34da38254bag" src="https://github.com/user-attachments/assets/d71659da-f95e-4871-93be-7012a94b3b4e" />


**Impact**
Sequence files with long RF delays can now be read correctly by the C++ parser.
No change to numerical precision (delay is an integer-valued quantity).
