### PR TITLE
Match make_trapezoid to Pulseq MATLAB output

### DIFF
--- a/src/pypulseq/make_trapezoid.py
+++ b/src/pypulseq/make_trapezoid.py
@@ -158,10 +158,10 @@ def make_trapezoid(
         # We have area and duration.
         if duration is not None and flat_time is None:
             if rise_time is None:
-                _, rise_time, flat_time, fall_time = calculate_shortest_params_for_area(
+                _, min_rise_time, min_flat_time, min_fall_time = calculate_shortest_params_for_area(
                     area, max_slew, max_grad, system.grad_raster_time
                 )
-                min_duration = rise_time + flat_time + fall_time
+                min_duration = min_rise_time + min_flat_time + min_fall_time
                 assert duration >= min_duration, (
                     f'Requested area is too large for this gradient. Minimum required duration is '
                     f'{round(min_duration * 1e6)} us'
@@ -169,6 +169,8 @@ def make_trapezoid(
 
                 dc = 1 / abs(2 * max_slew) + 1 / abs(2 * max_slew)
                 amplitude2 = (duration - math.sqrt(duration**2 - 4 * abs(area) * dc)) / (2 * dc)
+                rise_time = calculate_shortest_rise_time(amplitude2, max_slew, system.grad_raster_time)
+                fall_time = rise_time
             else:
                 if duration <= (rise_time + eps):
                     raise ValueError('The `duration` is too short for the given `rise_time`.')

--- a/tests/test_make_trapezoid.py
+++ b/tests/test_make_trapezoid.py
@@ -122,7 +122,7 @@ def test_generation_methods():
 
     # area + duration
     trap = make_trapezoid(channel='x', area=1, duration=1)
-    compare_trap_out(trap, 1.00002, 2e-5, 1 - 4e-5, 2e-5)
+    compare_trap_out(trap, 1.000010000100001, 1e-5, 1 - 2e-5, 1e-5)
 
     # area + duration + rise_time
     trap = make_trapezoid(channel='x', area=1, duration=1, rise_time=0.01)
@@ -130,3 +130,19 @@ def test_generation_methods():
     # flat_time + area + rise_time
     trap = make_trapezoid(channel='x', flat_time=0.5, area=1, rise_time=0.1)
     compare_trap_out(trap, 1 / 0.6, 0.1, 0.5, 0.1)
+
+
+def test_area_duration_matches_matlab_make_trapezoid_reference():
+    system = Opts(max_grad=100, grad_unit='mT/m', max_slew=100, slew_unit='T/m/s')
+
+    trap = make_trapezoid(channel='x', area=250, duration=1e-3, system=system)
+
+    compare_trap_out(
+        trap,
+        amplitude=268817.20430107525,
+        rise_time=7.000000000000001e-05,
+        flat_time=0.0008600000000000001,
+        fall_time=7.000000000000001e-05,
+    )
+    assert abs(trap.area - 250.0) < eps
+    assert abs(trap.flat_area - 231.18279569892474) < eps


### PR DESCRIPTION
## Summary
This PR updates `make_trapezoid(...)` to match MATLAB Pulseq `makeTrapezoid(...)` for equivalent inputs. 

The main behavioral fix is the `area + duration` path. PyPulseq previously calculated shortest timing first, rounded ramp times, and then solved the requested duration. MATLAB Pulseq first solves the quadratic amplitude for the requested area/duration, rounds the ramp time from that amplitude, and finally recalculates amplitude after raster rounding. That produces different ramp/flat timing and amplitude for the same input.

## Problem
For the same nominal input:

```python
system = pp.Opts(max_grad=100, grad_unit='mT/m', max_slew=100, slew_unit='T/m/s')
gx = pp.make_trapezoid(channel='x', area=250, duration=1e-3, system=system)
```

PyPulseq and Pulseq produces different trapezoids. 

<img width="1280" height="768" alt="trapezoid_comparison" src="https://github.com/user-attachments/assets/96b6071c-5c25-4ef8-8817-cd7037e1b137" />

As PyPulseq is described as a translation of Pulseq, this is a bug.

## What Changed
- Changes the `area + duration` branch to match Pulseq's quadratic solve plus post-raster amplitude recalculation.
- Derives the rasterized rise and fall times from the solved amplitude, using PyPulseq's existing rise-time helper.
- Keeps the existing `make_trapezoid(...)` API and all unrelated validation behavior unchanged.
- Adds a MATLAB reference regression test and updates the existing affected expectation.

## Behavior Compatibility
This is a bug-fix change limited to `area + duration` when ramp times are not supplied. That path now returns MATLAB-compatible timing and amplitude; other input combinations retain their existing PyPulseq behavior.

## Reference Output
The regression test anchors this Pulseq-compatible output:

```text
amplitude=268817.20430107525
rise_time=7.000000000000001e-05
flat_time=0.0008600000000000001
fall_time=7.000000000000001e-05
area=250.0
flat_area=231.18279569892474
```

## Testing
```text
PYTHONPATH=src python -m pytest tests/test_make_trapezoid.py
11 passed

python -m ruff check src/pypulseq/make_trapezoid.py tests/test_make_trapezoid.py
All checks passed!
```
