### PR TITLE
Improve gradient raster time accuracy for split_gradient_at function

### DIFF
--- a/src/pypulseq/split_gradient_at.py
+++ b/src/pypulseq/split_gradient_at.py
@@ -122,7 +122,7 @@ def split_gradient_at(
         time_point -= grad.delay
 
     amplitudes = np.array(amplitudes)
-    times = np.array(times).round(6)  # Work around floating-point arithmetic limitation
+    times = np.array(times).round(7)  # Work around floating-point arithmetic limitation
 
     # Sample at time point
     amp_tp = np.interp(x=time_point, xp=times, fp=amplitudes)

--- a/src/pypulseq/split_gradient_at.py
+++ b/src/pypulseq/split_gradient_at.py
@@ -55,7 +55,7 @@ def split_gradient_at(
 
     time_index = round(time_point / grad_raster_time)
     # Work around floating-point arithmetic limitation
-    time_point = round(time_index * grad_raster_time, 6)
+    time_point = round(time_index * grad_raster_time, 7)
     channel = grad.channel
 
     if grad.type == 'grad':


### PR DESCRIPTION
Some vendors use sub mu second gradient raster times. This leads to "not on raster" errors with the current code. This PR fixes this by increasing the accuracy of the rounding carried out in `split_gradient_at`